### PR TITLE
Add enough scaling factor metadata to keep ApPredict happy

### DIFF
--- a/oxford-metadata.rdf
+++ b/oxford-metadata.rdf
@@ -4,23 +4,30 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 >
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Calcium reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
+    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate_tau">
@@ -28,589 +35,484 @@
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
     <rdfs:label>Membrane fast sodium current j gate tau</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward current</rdfs:label>
-    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
-    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
-    <rdfs:comment>Often known as INaK_max</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
-    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
-    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane leakage current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular chloride concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane stimulus current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
-    <rdfs:label>Cell type</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
-    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Membrane leakage current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
-    <rdfs:label>Membrane persistent sodium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular">
-    <rdfs:label>Ventricular</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
-    <rdfs:label>Potassium channel n gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:label>Mammalian</rdfs:label>
-    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
-    <rdfs:label>Left ventricular</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
-    <rdfs:label>State variable</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
-    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump">
-    <rdfs:label>Pumps</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#seal_resistance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Patch clamp seal resistance</rdfs:comment>
-    <rdfs:label>Patch clamp seal resistance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
-    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
-    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane fast transient outward current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane slow transient outward current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
-    <rdfs:label>Membrane potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
-    <rdfs:label>Extracellular calcium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
+    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Ionic concentrations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
-    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
-    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#concentration_clamp_onoff">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Deprecated</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
-    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdfs:label>Cell membrane capacitance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance_scaling_factor">
-    <rdfs:label>Membrane L-type calcium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane transient outward current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
-    <rdfs:label>Species</rdfs:label>
-    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast transient outward current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
-    <rdfs:label>Faraday's constant - F</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_end">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdfs:label>Membrane stimulus current pulse end time</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel">
-    <rdfs:label>Chloride ion channels</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdfs:comment>The independent variable, the simulation time.</rdfs:comment>
-    <rdfs:label>Time</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#bath_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>TODO!</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Concentration of potassium in the bath</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Physical properties</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdfs:label>Membrane fast sodium current conductance scaling factor</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
-    <rdfs:label>The value of a measured quantity</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-    <rdfs:label>Potassium ion channels</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Voltage across the cell membrane</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sodium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
     <rdfs:label>Sodium reversal potential</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
     <rdfs:comment>Reversal potential of sodium ions across the cell membrane</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
-    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
+    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent">
+    <rdfs:label>Membrane currents</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
+    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:comment>Proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
-    <rdfs:label>Pumps</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
+    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
-    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current conductance scaling factor</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
-    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
-    <rdfs:label>A category of annotations</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
+    <rdfs:label>Ion channels</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#NSR_calcium_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:comment>The network SR is the non-junctional part of the SR.</rdfs:comment>
-    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
+    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
+    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_chloride_concentration">
-    <rdfs:label>Cytosolic chloride concentration</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rabbit">
-    <rdfs:label>Rabbit</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
-    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
+    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#right_ventricular">
-    <rdfs:label>Right ventricular</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
-    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
+    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchanger">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
+    <rdfs:label>Exchangers</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
+    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow transient outward current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
+    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Chloride reversal potential</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period">
     <rdfs:label>Membrane stimulus current pulse period</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
+    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane leakage current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane background calcium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
+    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic chloride concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
+    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
+    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
+    <rdfs:label>Implicit Variable Annotation</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
+    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane fast transient outward current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sino_atrial_node">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Sino-atrial node</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration">
+    <rdfs:label>Cytosolic ionic concentrations</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
+    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
+    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcacyt">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:label>Sarcoplasmic reticulum release kmcacyt</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
+    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
+    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane background sodium current</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
+    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
-    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
+    <rdfs:label>Faraday's constant - F</rdfs:label>
+    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdfs:label>Chloride reversal potential</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
+    <rdfs:label>Extracellular sodium concentration</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:label>Ion channels</rdfs:label>
-    <rdfs:comment>Proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current">
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow transient outward current</rdfs:label>
-    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
+    <rdfs:label>Membrane potassium current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
+    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Membrane L-type calcium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane calcium pump current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
+    <rdfs:label>A category of annotations</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular chloride concentration</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
-    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
+    <rdfs:comment>TODO!</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdfs:label>Membrane slow inward current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
+    <rdfs:label>Patch clamp properties</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
+    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance_scaling_factor">
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:label>Membrane persistent sodium current conductance scaling factor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance_scaling_factor">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current">
-    <rdfs:label>Membrane potassium pump current</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
-    <rdfs:label>Ion channels</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
+    <rdfs:label>Membrane plateau potassium current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_r_gate">
+    <rdfs:label>Membrane transient outward current r gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time">
+    <rdfs:comment>The independent variable, the simulation time.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Time</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane stimulus current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
+    <rdfs:label>Pumps</rdfs:label>
+    <rdfs:comment>Proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
+    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance scaling factor</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
+    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane transient outward current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#endocardial">
+    <rdfs:label>(Sub)endocardial</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
+    <rdfs:label>Membrane background chloride current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump">
+    <rdfs:label>Pumps</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance_scaling_factor">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
@@ -618,11 +520,231 @@
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdfs:label>Membrane sodium-calcium exchanger current conductance scaling factor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
+    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
+    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dog">
+    <rdfs:label>Dog</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
+    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane background potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
+    <rdfs:label>Ion channels</rdfs:label>
+    <rdfs:comment>Proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Cell type</rdfs:label>
+    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
+    <rdfs:label>Mammalian</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
+    <rdfs:comment>TODO!</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Potassium reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
+    <rdfs:label>Membrane L-type calcium channel sodium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
+    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Ventricular</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
+    <rdfs:label>Universal constants</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:label>Membrane fast sodium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular calcium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
+    <rdfs:label>The units of a measured quantity</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
+    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
+    <rdfs:label>Chloride ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane transient outward current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Calcium reversal potential</rdfs:label>
+    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
+    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane persistent sodium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+    <rdfs:comment>NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR).</rdfs:comment>
+    <rdfs:label>Sodium-calcium exchanger current into dyadic space</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdfs:label>Cell membrane capacitance</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_chloride_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
@@ -630,25 +752,326 @@
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
-    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#concentration_clamp_onoff">
+    <rdfs:comment>Deprecated</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate">
-    <rdfs:label>Membrane fast sodium current h gate</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
+    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
+    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
-    <rdfs:label>Membrane slow inward current</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
+    <rdfs:label>Variable Annotation</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
+    <rdfs:label>SR currents</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
+    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
+    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdfs:label>Stimulus current properties</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:label>Membrane fast sodium current h gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
+    <rdfs:comment>Often known as INaK_max</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Extracellular potassium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance_scaling_factor">
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast transient outward current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
+    <rdfs:label>Buffering</rdfs:label>
+    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
+    <rdfs:comment>Proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
+    <rdfs:label>Exchangers</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
+    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
+    <rdfs:label>State variable</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
+    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Species</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance_scaling_factor">
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow transient outward current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Temperature</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane background sodium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
+    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
+    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#bath_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>TODO!</rdfs:comment>
+    <rdfs:label>Concentration of potassium in the bath</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Potassium channel n gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel">
+    <rdfs:label>Mixed ion channels</rdfs:label>
+    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel">
+    <rdfs:label>Sodium ion channels</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+    <rdfs:label>Membrane potassium pump current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rabbit">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Rabbit</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Ionic concentrations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#right_ventricular">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
+    <rdfs:label>Right ventricular</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
+    <rdfs:label>The value of a measured quantity</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
+    <rdfs:label>Left ventricular</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
+    <rdfs:label>Membrane transient outward chloride current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#seal_resistance">
+    <rdfs:label>Patch clamp seal resistance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Patch clamp seal resistance</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Concentration of calcium ions in the sub-membrane compartment</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
+    <rdfs:label>Temperature measurement</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
+    <rdfs:label>Potassium ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#epicardial">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>(Sub)epicardial</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
+    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
+    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
+    <rdfs:label>Calcium ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
+    <rdfs:label>Membrane background sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Physical properties</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration">
+    <rdfs:label>Ionic concentrations in the SR</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:comment>Core annotations needed for a model to work well with the Chaste simulator.</rdfs:comment>
+    <rdfs:label>Basic Chaste metadata</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#atrial">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Atrial</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
+    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata">
     <dcterms:abstract>Chaste metadata for annotating CellML files representing cardiac electrophysiology models.</dcterms:abstract>
-    <dcterms:creator>Chaste Development Team</dcterms:creator>
     <dcterms:license>Copyright (c) 2005-2020, University of Oxford.
 All rights reserved.
 
@@ -680,454 +1103,31 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </dcterms:license>
+    <dcterms:creator>Chaste Development Team</dcterms:creator>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_end">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane background calcium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger">
-    <rdfs:label>Exchangers</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:comment>Proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane background sodium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
-    <rdfs:label>Membrane calcium pump current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_concentration">
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:label>Concentration of calcium ions in the sub-membrane compartment</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchanger">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
-    <rdfs:label>Exchangers</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Core annotations needed for a model to work well with the Chaste simulator.</rdfs:comment>
-    <rdfs:label>Basic Chaste metadata</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sodium-calcium exchanger current into dyadic space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdfs:comment>NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent">
-    <rdfs:label>SR currents</rdfs:label>
-    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_r_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward current r gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane leakage current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane plateau potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
-    <rdfs:label>Temperature</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current_conductance">
-    <rdfs:label>Membrane transient outward chloride current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#epicardial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>(Sub)epicardial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
-    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel">
-    <rdfs:label>Sodium ion channels</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
-    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Implicit Variable Annotation</rdfs:label>
-    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel">
-    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
-    <rdfs:label>Mixed ion channels</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
-    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast sodium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane persistent sodium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>TODO!</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane potassium current</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast sodium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent">
-    <rdfs:label>Stimulus current properties</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>TODO!</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
-    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular potassium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Potassium reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
-    <rdfs:label>Extracellular sodium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
-    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
-    <rdfs:label>Temperature measurement</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdfs:label>Voltage across the cell membrane</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
-    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
-    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
-    <rdfs:label>Variable Annotation</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dog">
-    <rdfs:label>Dog</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
-    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane background potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
-    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
-    <rdfs:label>The units of a measured quantity</rdfs:label>
-    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
-    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane background chloride current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration">
-    <rdfs:label>Ionic concentrations in the SR</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
-    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
+    <rdfs:label>Membrane stimulus current pulse end time</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Buffering</rdfs:label>
-    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#endocardial">
-    <rdfs:label>(Sub)endocardial</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
-    <rdfs:label>Membrane currents</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
-    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sino_atrial_node">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Sino-atrial node</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#atrial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Atrial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration">
-    <rdfs:label>Cytosolic ionic concentrations</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
-    <rdfs:label>Patch clamp properties</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-    <rdfs:label>Calcium ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Universal constants</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
-    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
   </rdf:Description>
 </rdf:RDF>

--- a/oxford-metadata.rdf
+++ b/oxford-metadata.rdf
@@ -4,448 +4,651 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 >
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
-    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Buffering</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow transient outward current</rdfs:label>
-    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
-    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#right_ventricular">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
-    <rdfs:label>Right ventricular</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
-    <rdfs:label>Patch clamp properties</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Calcium reversal potential</rdfs:label>
+    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
-    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Core annotations needed for a model to work well with the Chaste simulator.</rdfs:comment>
-    <rdfs:label>Basic Chaste metadata</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
-    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
-    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Extracellular chloride concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane calcium pump current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
-    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current">
-    <rdfs:label>Membrane potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdfs:label>Time</rdfs:label>
-    <rdfs:comment>The independent variable, the simulation time.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
-    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
-    <rdfs:label>Cell type</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
-    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
-    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_r_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward current r gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
-    <rdfs:comment>TODO!</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
-    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchanger">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
-    <rdfs:label>Exchangers</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane background calcium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
-    <rdfs:label>State variable</rdfs:label>
-    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
-    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent">
-    <rdfs:label>Membrane currents</rdfs:label>
-    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
-    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast transient outward current</rdfs:label>
-    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger">
-    <rdfs:label>Exchangers</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:comment>Proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate_tau">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
+    <rdfs:label>Membrane fast sodium current j gate tau</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>SR currents</rdfs:label>
-    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
-    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
-    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane transient outward current</rdfs:label>
+    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:label>Pumps</rdfs:label>
-    <rdfs:comment>Proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
+    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdfs:label>Membrane background chloride current</rdfs:label>
+    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
+    <rdfs:comment>Often known as INaK_max</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
-    <rdfs:label>Implicit Variable Annotation</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
-    <rdfs:label>Calcium reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
+    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
+    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
-    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
-    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Potassium channel n gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Extracellular calcium concentration</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast sodium current j gate tau</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
-    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
-    <rdfs:label>Species</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular potassium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
-    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Extracellular chloride concentration</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdfs:label>Concentration of calcium ions in the sub-membrane compartment</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
-    <rdfs:label>Physical properties</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
-    <rdfs:label>Ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>TODO!</rdfs:comment>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Temperature</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Voltage across the cell membrane</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
-    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:label>Membrane stimulus current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
+    <rdfs:label>Cell type</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
+    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Membrane leakage current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
+    <rdfs:label>Membrane persistent sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular">
+    <rdfs:label>Ventricular</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
+    <rdfs:label>Potassium channel n gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Mammalian</rdfs:label>
+    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
+    <rdfs:label>Left ventricular</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
+    <rdfs:label>State variable</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
+    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump">
+    <rdfs:label>Pumps</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#seal_resistance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Patch clamp seal resistance</rdfs:comment>
+    <rdfs:label>Patch clamp seal resistance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
+    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
+    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane fast transient outward current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane slow transient outward current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
+    <rdfs:label>Membrane potassium current conductance</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
+    <rdfs:label>Extracellular calcium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
+    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Ionic concentrations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
+    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
+    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
+    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#concentration_clamp_onoff">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Deprecated</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
+    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Cell membrane capacitance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance_scaling_factor">
+    <rdfs:label>Membrane L-type calcium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane transient outward current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
+    <rdfs:label>Species</rdfs:label>
+    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast transient outward current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
+    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
+    <rdfs:label>Faraday's constant - F</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_end">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
+    <rdfs:label>Membrane stimulus current pulse end time</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel">
+    <rdfs:label>Chloride ion channels</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:comment>The independent variable, the simulation time.</rdfs:comment>
+    <rdfs:label>Time</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#bath_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>TODO!</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Concentration of potassium in the bath</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Physical properties</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdfs:label>Membrane fast sodium current conductance scaling factor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
+    <rdfs:label>The value of a measured quantity</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
+    <rdfs:label>Potassium ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sodium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Sodium reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Reversal potential of sodium ions across the cell membrane</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
+    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium channel sodium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
+    <rdfs:comment>Proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
+    <rdfs:label>Pumps</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
+    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current conductance scaling factor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
+    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
+    <rdfs:label>A category of annotations</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#NSR_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>The network SR is the non-junctional part of the SR.</rdfs:comment>
+    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_chloride_concentration">
+    <rdfs:label>Cytosolic chloride concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rabbit">
+    <rdfs:label>Rabbit</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
+    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#right_ventricular">
+    <rdfs:label>Right ventricular</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
+    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period">
+    <rdfs:label>Membrane stimulus current pulse period</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcacyt">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sarcoplasmic reticulum release kmcacyt</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:label>Membrane background sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
+    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
+    <rdfs:label>Chloride reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
+    <rdfs:label>Ion channels</rdfs:label>
+    <rdfs:comment>Proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow transient outward current</rdfs:label>
+    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
+    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current">
+    <rdfs:label>Membrane potassium pump current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
+    <rdfs:label>Ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane inward rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:label>Concentration of chloride ions in the sub-membrane compartment</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
+    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate">
+    <rdfs:label>Membrane fast sodium current h gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
+    <rdfs:label>Membrane slow inward current</rdfs:label>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
-    <rdfs:comment>Often known as INaK_max</rdfs:comment>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata">
+    <dcterms:abstract>Chaste metadata for annotating CellML files representing cardiac electrophysiology models.</dcterms:abstract>
+    <dcterms:creator>Chaste Development Team</dcterms:creator>
     <dcterms:license>Copyright (c) 2005-2020, University of Oxford.
 All rights reserved.
 
@@ -477,495 +680,100 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </dcterms:license>
-    <dcterms:abstract>Chaste metadata for annotating CellML files representing cardiac electrophysiology models.</dcterms:abstract>
-    <dcterms:creator>Chaste Development Team</dcterms:creator>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow inward current</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
-    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#seal_resistance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Patch clamp seal resistance</rdfs:label>
-    <rdfs:comment>Patch clamp seal resistance</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
-    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel">
-    <rdfs:label>Potassium ion channels</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#concentration_clamp_onoff">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Deprecated</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-    <rdfs:label>Membrane potassium pump current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
-    <rdfs:label>Membrane transient outward current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane background sodium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel">
-    <rdfs:label>Calcium ion channels</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Membrane background calcium current</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdfs:label>Membrane stimulus current pulse period</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel">
-    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
-    <rdfs:label>Mixed ion channels</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
-    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
-    <rdfs:label>Potassium reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger">
+    <rdfs:label>Exchangers</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:label>Stimulus current properties</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdfs:label>Cell membrane capacitance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
-    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdfs:comment>NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR).</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sodium-calcium exchanger current into dyadic space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane fast sodium current h gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular sodium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdfs:label>Membrane leakage current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane plateau potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
-    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
-    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-    <rdfs:label>Sodium ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump">
-    <rdfs:label>Pumps</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
-    <rdfs:label>Universal constants</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
-    <rdfs:label>Faraday's constant - F</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
-    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
-    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
-    <rdfs:label>Variable Annotation</rdfs:label>
-    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
-    <rdfs:label>Left ventricular</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
+    <rdfs:comment>Proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
     <rdfs:label>Membrane background sodium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
-    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_chloride_concentration">
+    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of chloride ions in the sub-membrane compartment</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
-    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
+    <rdfs:label>Membrane calcium pump current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_concentration">
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:label>Concentration of calcium ions in the sub-membrane compartment</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>A category of annotations</rdfs:label>
-    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchanger">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
+    <rdfs:label>Exchangers</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:comment>Core annotations needed for a model to work well with the Chaste simulator.</rdfs:comment>
+    <rdfs:label>Basic Chaste metadata</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Membrane leakage current conductance</rdfs:label>
+    <rdfs:label>Sodium-calcium exchanger current into dyadic space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
+    <rdfs:comment>NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR).</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
-    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Chloride reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
-    <rdfs:label>The units of a measured quantity</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
-    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Ventricular</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane background potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
-    <rdfs:label>Ionic concentrations</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent">
+    <rdfs:label>SR currents</rdfs:label>
+    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_r_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane transient outward current r gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdfs:label>Membrane leakage current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
+    <rdfs:label>Membrane plateau potassium current</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast sodium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
-    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sodium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Sodium reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential of sodium ions across the cell membrane</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>Temperature measurement</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration">
-    <rdfs:label>Cytosolic ionic concentrations</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
-    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#NSR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
-    <rdfs:comment>The network SR is the non-junctional part of the SR.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#bath_potassium_concentration">
-    <rdfs:comment>TODO!</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Concentration of potassium in the bath</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
-    <rdfs:label>Mammalian</rdfs:label>
-    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Cytosolic chloride concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance">
-    <rdfs:label>Membrane fast sodium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
+    <rdfs:label>Temperature</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current_conductance">
@@ -973,75 +781,353 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
-    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-  </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#epicardial">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Epicardial cell</rdfs:label>
+    <rdfs:label>(Sub)epicardial</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane persistent sodium current</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
+    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
+    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel">
+    <rdfs:label>Sodium ion channels</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
+    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_end">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Implicit Variable Annotation</rdfs:label>
+    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdfs:label>Membrane stimulus current pulse end time</rdfs:label>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel">
-    <rdfs:comment>Proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
-    <rdfs:label>Ion channels</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel">
+    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
+    <rdfs:label>Mixed ion channels</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
+    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane persistent sodium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>TODO!</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
+    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane potassium current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent">
+    <rdfs:label>Stimulus current properties</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:comment>TODO!</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
+    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
+    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular potassium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Potassium reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
+    <rdfs:label>Extracellular sodium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
+    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
+    <rdfs:label>Temperature measurement</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Voltage across the cell membrane</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
+    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
+    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
+    <rdfs:label>Variable Annotation</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dog">
+    <rdfs:label>Dog</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
-    <rdfs:label>The value of a measured quantity</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
+    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane background potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
+    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
+    <rdfs:label>The units of a measured quantity</rdfs:label>
+    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
+    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane background chloride current</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration">
     <rdfs:label>Ionic concentrations in the SR</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
-    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
+    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
-    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcacyt">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Buffering</rdfs:label>
+    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#endocardial">
+    <rdfs:label>(Sub)endocardial</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sarcoplasmic reticulum release kmcacyt</rdfs:label>
+    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
-    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
+    <rdfs:label>Membrane currents</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
+    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sino_atrial_node">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Sino-atrial node</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#atrial">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Atrial</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration">
+    <rdfs:label>Cytosolic ionic concentrations</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
+    <rdfs:label>Patch clamp properties</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-    <rdfs:label>Chloride ion channels</rdfs:label>
+    <rdfs:label>Calcium ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Universal constants</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
+    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
   </rdf:Description>
 </rdf:RDF>

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -58,6 +58,14 @@
     a :Species ;
     rdfs:label "Human (Homo Sapiens)" .
 
+:rabbit
+    a :Species ;
+    rdfs:label "Rabbit" .
+
+:dog
+    a :Species ;
+    rdfs:label "Dog" .
+
 :mammalian
     a :Species ;
     rdfs:label "Mammalian" ;
@@ -78,6 +86,14 @@
     a :CellType ;
     rdfs:label "Human induced pluripotent stem cell" .
 
+:atrial
+    a :CellType ;
+    rdfs:label "Atrial" .
+
+:sino_atrial_node
+    a :CellType ;
+    rdfs:label "Sino-atrial node" .
+
 :ventricular
     a :CellType ;
     rdfs:label "Ventricular" .
@@ -92,7 +108,11 @@
 
 :epicardial
     a :CellType ;
-    rdfs:label "Epicardial cell" .
+    rdfs:label "(Sub)epicardial" .
+
+:endocardial
+    a :CellType ;
+    rdfs:label "(Sub)endocardial" .
 
 # etc. TODO
 
@@ -623,6 +643,12 @@
     a :MembraneSodiumChannel ;
     rdfs:label "Membrane fast sodium current conductance" .
 
+:membrane_fast_sodium_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembraneSodiumChannel ;
+    rdfs:label "Membrane fast sodium current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
+
 :membrane_fast_sodium_current_m_gate
     a :Annotation ;
     a :MembraneSodiumChannel ;
@@ -672,6 +698,11 @@
     rdfs:label "Membrane persistent sodium current conductance" ;
     rdfs:comment "Also known as membrane late sodium current conductance" .
 
+:membrane_persistent_sodium_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembraneSodiumChannel ;
+    rdfs:label "Membrane persistent sodium current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 # I Na,b (background)
 :membrane_background_sodium_current
@@ -700,6 +731,12 @@
     a :MembranePotassiumChannel ;
     rdfs:label "Membrane rapid delayed rectifier potassium current conductance" .
 
+:membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembranePotassiumChannel ;
+    rdfs:label "Membrane rapid delayed rectifier potassium current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
+
 :membrane_rapid_delayed_rectifier_potassium_current_conductance1
     a :Annotation ;
     a :MembranePotassiumChannel ;
@@ -722,6 +759,12 @@
     a :Annotation ;
     a :MembranePotassiumChannel ;
     rdfs:label "Membrane slow delayed rectifier potassium current conductance" .
+
+:membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembranePotassiumChannel ;
+    rdfs:label "Membrane slow delayed rectifier potassium current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau
     a :Annotation ;
@@ -746,6 +789,12 @@
     a :MembranePotassiumChannel ;
     rdfs:label "Membrane ultrarapid delayed rectifier potassium current conductance" .
 
+:membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembranePotassiumChannel ;
+    rdfs:label "Membrane ultrarapid delayed rectifier potassium current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
+
 # I_Kss or Iss
 :membrane_non_inactivating_steady_state_potassium_current
     a :Annotation ;
@@ -768,6 +817,12 @@
     a :MembranePotassiumChannel ;
     rdfs:label "Membrane inward rectifier potassium current conductance" .
 
+:membrane_inward_rectifier_potassium_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembranePotassiumChannel ;
+    rdfs:label "Membrane inward rectifier potassium current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
+
 # I to, (a.k.a. I_to1) sometimes fast and slow components, sometimes not.
 :membrane_transient_outward_current
     a :Annotation ;
@@ -779,6 +834,12 @@
     a :Annotation ;
     a :MembranePotassiumChannel ;
     rdfs:label "Membrane transient outward current conductance" .
+
+:membrane_transient_outward_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembranePotassiumChannel ;
+    rdfs:label "Membrane transient outward current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_fast_transient_outward_current
     a :Annotation ;
@@ -796,6 +857,12 @@
     a :MembranePotassiumChannel ;
     rdfs:label "Membrane fast transient outward current conductance" .
 
+:membrane_fast_transient_outward_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembranePotassiumChannel ;
+    rdfs:label "Membrane fast transient outward current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
+
 :membrane_slow_transient_outward_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
@@ -811,6 +878,12 @@
     a :Annotation ;
     a :MembranePotassiumChannel ;
     rdfs:label "Membrane slow transient outward current conductance" .
+
+:membrane_slow_transient_outward_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembranePotassiumChannel ;
+    rdfs:label "Membrane slow transient outward current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_transient_outward_current_time_independent_rectification_gate_constant
     a :Annotation ;
@@ -952,6 +1025,12 @@
     a :MembraneCalciumChannel ;
     rdfs:label "Membrane L-type calcium current conductance" .
 
+:membrane_L_type_calcium_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembraneCalciumChannel ;
+    rdfs:label "Membrane L-type calcium current conductance scaling factor" ;
+    rdfs:comment "A scalar that multiplies the conductance term for this current" .
+
 :membrane_L_type_calcium_current_d_gate
     a :Annotation ;
     a :MembraneCalciumChannel ;
@@ -1088,6 +1167,12 @@
     a :Annotation ;
     a :MembraneExchanger ;
     rdfs:label "Membrane sodium-calcium exchanger current conductance" ;
+    rdfs:comment "Also known as permeability" .
+
+:membrane_sodium_calcium_exchanger_current_conductance_scaling_factor
+    a :Annotation ;
+    a :MembraneExchanger ;
+    rdfs:label "Membrane sodium-calcium exchanger current conductance scaling factor" ;
     rdfs:comment "Also known as permeability" .
 
 :membrane_sodium_calcium_exchanger_dyadic_space_current


### PR DESCRIPTION
This pull request tidies up a few loose ends in the metadata definition, but mainly adds scaling factors for each conductance which [ApPredict](https://chaste.cs.ox.ac.uk/trac/wiki/ApPredict) uses, so that Chaste can switch to using this ontology and work with the same set of CellML files (still to be updated).