### PR TITLE
Update oxford-metadata.ttl

### DIFF
--- a/oxford-metadata.rdf
+++ b/oxford-metadata.rdf
@@ -4,666 +4,187 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 >
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular potassium concentration</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Chloride reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
-    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
-    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane persistent sodium current</rdfs:label>
-    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
-    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
-    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
-    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>The units of a measured quantity</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#epicardial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>(Sub)epicardial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchanger">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
-    <rdfs:label>Exchangers</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdfs:label>Membrane fast transient outward current conductance scaling factor</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent">
-    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Membrane currents</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
-    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#endocardial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>(Sub)endocardial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>TODO!</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
-    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_r_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward current r gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdfs:label>Membrane slow transient outward current conductance scaling factor</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_end">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane stimulus current pulse end time</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:label>Stimulus current properties</rdfs:label>
+    <rdfs:label>Stimulus current and its properties</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance_scaling_factor">
+    <rdfs:label>Membrane inward rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
+    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_concentration">
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:label>Concentration of calcium ions in the sub-membrane compartment</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset">
+    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_ohmic_driving_term">
+    <rdfs:label>Membrane L-type calcium current Ohmic driving term</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane background sodium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
+    <rdfs:label>Patch clamp properties</rdfs:label>
+    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Calcium reversal potential</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane potassium current</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:label>Ion channels</rdfs:label>
-    <rdfs:comment>Proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdfs:label>Membrane persistent sodium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane fast sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
+    <rdfs:label>The units of a measured quantity</rdfs:label>
+    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane background chloride current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
+    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
+    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current_conductance">
+    <rdfs:label>Membrane leakage current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_delayed_rectifier_potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>IKr reversal potential</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Reversal potential for the IKr current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance_scaling_factor">
     <rdfs:label>Membrane transient outward current conductance scaling factor</rdfs:label>
     <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CustomAnnotations">
-    <rdfs:comment>Custom annotations in other namespaces referenced by protocols.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Custom annotations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Physical properties</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-    <rdfs:comment>Often known as INaK_max</rdfs:comment>
-    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
-    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current driving term (GHK or ohmic)</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane potassium current conductance</rdfs:label>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Membrane plateau potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of chloride ions in the sub-membrane compartment</rdfs:label>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
-    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
-    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
-    <rdfs:label>Variable Annotation</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
-    <rdfs:label>Membrane calcium pump current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration">
-    <rdfs:label>Ionic concentrations in the SR</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current conductance or permeability</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
-    <rdfs:label>Potassium reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#bath_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Concentration of potassium in the bath</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>TODO!</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_ohmic_driving_term">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current Ohmic driving term</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Potassium channel n gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
-    <rdfs:label>Temperature measurement</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
-    <rdfs:label>Ionic concentrations</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Membrane leakage current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#NSR_calcium_concentration">
-    <rdfs:comment>The network SR is the non-junctional part of the SR.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_delayed_rectifier_potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:comment>Reversal potential for the IKs current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
-    <rdfs:label>IKs reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
-    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
-    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
-    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
-    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane slow transient outward current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
-    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast sodium current j gate tau</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
-    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane transient outward current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
-    <rdfs:label>State variable</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
-    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_GHK_driving_term">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current GHK driving term</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
-    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdfs:label>Cell membrane capacitance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdfs:label>Membrane stimulus current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdfs:label>Temperature</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdfs:label>Voltage across the cell membrane</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:label>Exchangers</rdfs:label>
-    <rdfs:comment>Proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Extracellular sodium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
-    <rdfs:label>Extracellular chloride concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
-    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
-    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
-    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdfs:label>Membrane background chloride current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
-    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#atrial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Atrial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current">
-    <rdfs:comment>NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR).</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdfs:label>Sodium-calcium exchanger current into dyadic space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular calcium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
-    <rdfs:label>Faraday's constant - F</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>TODO!</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sino_atrial_node">
-    <rdfs:label>Sino-atrial node</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
-    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane slow inward current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdfs:label>Membrane persistent sodium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
-    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata">
@@ -671,503 +192,1023 @@
     <rdfs:label>Basic Chaste metadata</rdfs:label>
     <rdfs:comment>Core annotations needed for a model to work well with the Chaste simulator.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
-    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
+    <rdfs:label>Faraday's constant - F</rdfs:label>
+    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdfs:label>Membrane fast sodium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
-    <rdfs:label>A category of annotations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-    <rdfs:label>Calcium ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
-    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
-    <rdfs:label>Patch clamp properties</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
-    <rdfs:label>Species</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
-    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast transient outward current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane leakage current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
-    <rdfs:label>Mixed ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
-    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
-    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent">
-    <rdfs:label>SR currents</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
-    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-    <rdfs:label>Chloride ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump">
-    <rdfs:label>Pumps</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrent"/>
-    <rdfs:comment>Proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
-    <rdfs:label>Universal constants</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular potassium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance_scaling_factor">
-    <rdfs:label>Membrane inward rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
-    <rdfs:label>The value of a measured quantity</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
     <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
+    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
-    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump"/>
-    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
-    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane background sodium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sodium_reversal_potential">
-    <rdfs:label>Sodium reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:comment>Reversal potential of sodium ions across the cell membrane</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane background potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane fast sodium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
-    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcacyt">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdfs:label>Sarcoplasmic reticulum release kmcacyt</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-    <rdfs:label>Potassium ion channels</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated">
+    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
+    <rdfs:label>Pumps</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
     <rdfs:comment>The independent variable, the simulation time.</rdfs:comment>
     <rdfs:label>Time</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
+    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance_scaling_factor">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast sodium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
-    <rdfs:label>Buffering</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
-    <rdfs:label>Ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdfs:label>Concentration of calcium ions in the sub-membrane compartment</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate">
-    <rdfs:label>Membrane fast sodium current h gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
-    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannel"/>
-    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannel"/>
-    <rdfs:label>Sodium ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane background calcium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane background sodium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
-    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane slow transient outward current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#concentration_clamp_onoff">
     <rdfs:comment>Deprecated</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
-    <rdfs:label>Left ventricular</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
+    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
+    <rdfs:label>Potassium reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dog">
-    <rdfs:label>Dog</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
+    <rdfs:label>Variable Annotation</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane calcium pump current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
+    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
+    <rdfs:label>Membrane background potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#epicardial">
+    <rdfs:label>(Sub)epicardial</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchangerRelated">
+    <rdfs:label>Exchangers</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane slow transient outward current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
+    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_end">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane stimulus current pulse end time</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
+    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#endocardial">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>(Sub)endocardial</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
+    <rdfs:label>Voltage across the cell membrane</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate">
+    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CustomAnnotations">
+    <rdfs:label>Custom annotations</rdfs:label>
+    <rdfs:comment>Custom annotations in other namespaces referenced by protocols.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Universal constants</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sodium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:comment>Reversal potential of sodium ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sodium reversal potential</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdfs:label>Membrane leakage current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
+    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
+    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
+    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_delayed_rectifier_potassium_reversal_potential">
+    <rdfs:label>IKs reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:comment>Reversal potential for the IKs current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane transient outward current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Cell membrane capacitance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated">
+    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Membrane currents and their properties</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#NSR_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>The network SR is the non-junctional part of the SR.</rdfs:comment>
+    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular sodium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane stimulus current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current h gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current driving term (GHK or ohmic)</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:label>Membrane potassium pump current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePump"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
-    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Cell type</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdfs:label>Membrane sodium-calcium exchanger current conductance scaling factor</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#seal_resistance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:label>Patch clamp seal resistance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
     <rdfs:comment>Patch clamp seal resistance</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance_scaling_factor">
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current conductance scaling factor</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current j gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#bath_potassium_concentration">
+    <rdfs:label>Concentration of potassium in the bath</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:comment>TODO!</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration">
+    <rdfs:label>Ionic concentrations in the SR</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
+    <rdfs:label>Membrane plateau potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_GHK_driving_term">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
+    <rdfs:label>Membrane L-type calcium current GHK driving term</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
+    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated">
+    <rdfs:comment>Terms related to proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:label>Pumps</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
+    <rdfs:label>Membrane fast transient outward current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR).</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Sodium-calcium exchanger current into dyadic space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
+    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
+    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane background calcium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
+    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Implicit Variable Annotation</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_delayed_rectifier_potassium_reversal_potential">
+    <rdfs:comment>Reversal potential for the IKr current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>IKr reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Often known as INaK_max</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
+    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
     <rdfs:label>Ventricular</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane L-type calcium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated">
+    <rdfs:label>Terms related to potassium ion channels</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Chloride reversal potential</rdfs:label>
+    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium channel sodium current conductance or permeability</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
+    <rdfs:label>Membrane slow inward current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>TODO!</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated">
+    <rdfs:label>Terms related to sodium ion channels</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:label>Ion channels</rdfs:label>
+    <rdfs:comment>Terms related to proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
+    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:comment>All terms that represent a current anywhere in the cell.</rdfs:comment>
+    <rdfs:label>Ionic currents</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dog">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Dog</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_open_probability">
+    <rdfs:label>Membrane L-type calcium current open probability</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated">
+    <rdfs:label>Terms related to mixed ion channels</rdfs:label>
+    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
+    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
+    <rdfs:comment>TODO!</rdfs:comment>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
+    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
+    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rabbit">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Rabbit</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
+    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
+    <rdfs:label>Species</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
+    <rdfs:label>Physical properties</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated">
+    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>SR currents</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_chloride_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
     <rdfs:label>Cytosolic chloride concentration</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Potassium channel n gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
-    <rdfs:label>Implicit Variable Annotation</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
+    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:label>Terms related to calcium ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata">
+    <dcterms:abstract>Chaste metadata for annotating CellML files representing cardiac electrophysiology models.</dcterms:abstract>
+    <dcterms:license>Copyright (c) 2005-2020, University of Oxford.&#13;
+All rights reserved.&#13;
+&#13;
+University of Oxford means the Chancellor, Masters and Scholars of the&#13;
+University of Oxford, having an administrative office at Wellington&#13;
+Square, Oxford OX1 2JD, UK.&#13;
+&#13;
+This file is part of Chaste.&#13;
+&#13;
+Redistribution and use in source and binary forms, with or without&#13;
+modification, are permitted provided that the following conditions are met:&#13;
+ * Redistributions of source code must retain the above copyright notice,&#13;
+   this list of conditions and the following disclaimer.&#13;
+ * Redistributions in binary form must reproduce the above copyright notice,&#13;
+   this list of conditions and the following disclaimer in the documentation&#13;
+   and/or other materials provided with the distribution.&#13;
+ * Neither the name of the University of Oxford nor the names of its&#13;
+   contributors may be used to endorse or promote products derived from this&#13;
+   software without specific prior written permission.&#13;
+&#13;
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"&#13;
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE&#13;
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE&#13;
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE&#13;
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR&#13;
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE&#13;
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)&#13;
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT&#13;
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT&#13;
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.&#13;
+</dcterms:license>
+    <dcterms:creator>Chaste Development Team</dcterms:creator>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
+    <rdfs:label>A category of annotations</rdfs:label>
+    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
+    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
+    <rdfs:label>State variable</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
-    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
-    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_open_probability">
-    <rdfs:label>Membrane L-type calcium current open probability</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
-    <rdfs:label>Mammalian</rdfs:label>
-    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdfs:label>Membrane slow delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:label>Membrane transient outward chloride current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rabbit">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:label>Rabbit</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchanger"/>
-    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period">
-    <rdfs:label>Membrane stimulus current pulse period</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:label>Concentration of chloride ions in the sub-membrane compartment</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
+    <rdfs:label>Cell type</rdfs:label>
+    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane background sodium current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
+    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
+    <rdfs:label>Temperature measurement</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
+    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcacyt">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sarcoplasmic reticulum release kmcacyt</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
+    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
     <rdfs:label>Cytosolic ionic concentrations</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPump">
-    <rdfs:label>Pumps</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrent"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdfs:label>Membrane stimulus current pulse period</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
+    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
+    <rdfs:label>Ion channels</rdfs:label>
+    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
+    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
+    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Temperature</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane fast transient outward current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Calcium reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Ionic concentrations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane persistent sodium current</rdfs:label>
+    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Extracellular calcium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
+    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:label>Terms related to chloride ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
+    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
+    <rdfs:label>Mammalian</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated">
+    <rdfs:label>Exchangers</rdfs:label>
+    <rdfs:comment>Terms related to proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#atrial">
+    <rdfs:label>Atrial</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
+    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sino_atrial_node">
+    <rdfs:label>Sino-atrial node</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#right_ventricular">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
     <rdfs:label>Right ventricular</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
-    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannel"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannel"/>
-    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
-    <rdfs:label>Membrane potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannel"/>
+    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata">
-    <dcterms:license>Copyright (c) 2005-2020, University of Oxford.
-All rights reserved.
-
-University of Oxford means the Chancellor, Masters and Scholars of the
-University of Oxford, having an administrative office at Wellington
-Square, Oxford OX1 2JD, UK.
-
-This file is part of Chaste.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
- * Neither the name of the University of Oxford nor the names of its
-   contributors may be used to endorse or promote products derived from this
-   software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</dcterms:license>
-    <dcterms:abstract>Chaste metadata for annotating CellML files representing cardiac electrophysiology models.</dcterms:abstract>
-    <dcterms:creator>Chaste Development Team</dcterms:creator>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
+    <rdfs:label>The value of a measured quantity</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
+    <rdfs:label>Buffering</rdfs:label>
+    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular chloride concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
+    <rdfs:label>Left ventricular</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
+    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_r_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane transient outward current r gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
 </rdf:RDF>

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -168,34 +168,34 @@
     rdfs:label "Pumps" ;
     rdfs:comment "Terms related to proteins that use energy in ATP to pump ions against their electrochemical gradients." .
 
-:MembraneExchanger
+:MembraneExchangerRelated
     a :CellMembraneCurrentRelated ;
     rdfs:label "Exchangers" ;
-    rdfs:comment "Proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient." .
+    rdfs:comment "Terms related to proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient." .
 
-:MembraneIonChannel
+:MembraneIonChannelRelated
     a :CellMembraneCurrentRelated ;
     rdfs:label "Ion channels" ;
-    rdfs:comment "Proteins allowing certain ions to flow down their electrochemical gradients." .
+    rdfs:comment "Terms related to proteins allowing certain ions to flow down their electrochemical gradients." .
 
 :MembranePotassiumChannel
-    a :MembraneIonChannel ;
+    a :MembraneIonChannelRelated ;
     rdfs:label "Potassium ion channels" .
 
 :MembraneSodiumChannel
-    a :MembraneIonChannel ;
+    a :MembraneIonChannelRelated ;
     rdfs:label "Sodium ion channels" .
 
 :MembraneCalciumChannel
-    a :MembraneIonChannel ;
+    a :MembraneIonChannelRelated ;
     rdfs:label "Calcium ion channels" .
 
 :MembraneChlorideChannel
-    a :MembraneIonChannel ;
+    a :MembraneIonChannelRelated ;
     rdfs:label "Chloride ion channels" .
 
 :MembraneMixedChannel
-    a :MembraneIonChannel ;
+    a :MembraneIonChannelRelated ;
     rdfs:label "Mixed ion channels" ;
     rdfs:comment "Membrane ion channels that don't fit a more specific categorisation, or transport multiple species." .
 
@@ -1234,32 +1234,32 @@
 # I NCX
 :membrane_sodium_calcium_exchanger_current
     a :Annotation ;
-    a :MembraneExchanger ;
+    a :MembraneExchangerRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane sodium-calcium exchanger current" .
 
 :membrane_sodium_calcium_exchanger_current_conductance
     a :Annotation ;
-    a :MembraneExchanger ;
+    a :MembraneExchangerRelated ;
     rdfs:label "Membrane sodium-calcium exchanger current conductance" ;
     rdfs:comment "Also known as permeability" .
 
 :membrane_sodium_calcium_exchanger_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembraneExchanger ;
+    a :MembraneExchangerRelated ;
     rdfs:label "Membrane sodium-calcium exchanger current conductance scaling factor" ;
     rdfs:comment "Also known as permeability" .
 
 :membrane_sodium_calcium_exchanger_dyadic_space_current
     a :Annotation ;
-    a :MembraneExchanger ;
+    a :MembraneExchangerRelated ;
     a :IonicCurrent ;
     rdfs:comment "NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR)." ;
     rdfs:label "Sodium-calcium exchanger current into dyadic space" .
 
 :membrane_sodium_calcium_exchanger_dyadic_space_current_conductance
     a :Annotation ;
-    a :MembraneExchanger ;
+    a :MembraneExchangerRelated ;
     rdfs:label "Sodium-calcium exchanger current into dyadic space conductance" ;
     rdfs:comment "Also known as permeability" .
 

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -209,7 +209,7 @@
     rdfs:label "SR currents" ;
     rdfs:comment "Annotations associated with currents across the sarcoplasmic reticulum membrane." .
 
-:SRPumpRelatedRelated
+:SRPumpRelated
     a :SRCurrentRelated ;
     rdfs:label "Pumps"  ;
     rdfs:comment "Terms related to proteins in the sarcoplasmic reticulum membrane that use energy in ATP to pump ions against their electrochemical gradients." .

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -173,29 +173,29 @@
     rdfs:label "Exchangers" ;
     rdfs:comment "Terms related to proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient." .
 
-:MembraneIonChannelRelated
+:MembraneIonChannel
     a :CellMembraneCurrentRelated ;
     rdfs:label "Ion channels" ;
     rdfs:comment "Terms related to proteins allowing certain ions to flow down their electrochemical gradients." .
 
 :MembranePotassiumChannel
-    a :MembraneIonChannelRelated ;
+    a :MembraneIonChannel ;
     rdfs:label "Potassium ion channels" .
 
 :MembraneSodiumChannel
-    a :MembraneIonChannelRelated ;
+    a :MembraneIonChannel ;
     rdfs:label "Sodium ion channels" .
 
 :MembraneCalciumChannel
-    a :MembraneIonChannelRelated ;
+    a :MembraneIonChannel ;
     rdfs:label "Calcium ion channels" .
 
 :MembraneChlorideChannel
-    a :MembraneIonChannelRelated ;
+    a :MembraneIonChannel ;
     rdfs:label "Chloride ion channels" .
 
 :MembraneMixedChannel
-    a :MembraneIonChannelRelated ;
+    a :MembraneIonChannel ;
     rdfs:label "Mixed ion channels" ;
     rdfs:comment "Membrane ion channels that don't fit a more specific categorisation, or transport multiple species." .
 

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -148,28 +148,38 @@
     a :Category ;
     rdfs:label "Physical properties" .
 
-:CellMembraneCurrent
+:IonicCurrent:
+    a :Category ;
+    rdfs:label "Ion currents" ;
+    rdfs:comment "Annotations of any kind of currents." .
+
+:CellMembraneCurrentRelated
+    a :Category ;
+    rdfs:label "Membrane currents" ;
+    rdfs:comment "Annotations associated with currents across the cell membrane." .
+
+:CellMembraneCurrentRelated
     a :Category ;
     rdfs:label "Membrane currents" ;
     rdfs:comment "Annotations associated with currents across the cell membrane." .
 
 :StimulusCurrent
-    a :CellMembraneCurrent ;
+    a :CellMembraneCurrentRelated ;
     a :ChasteMetadata ;
     rdfs:label "Stimulus current properties" .
 
 :MembranePump
-    a :CellMembraneCurrent ;
+    a :CellMembraneCurrentRelated ;
     rdfs:label "Pumps" ;
     rdfs:comment "Proteins that use energy in ATP to pump ions against their electrochemical gradients." .
 
 :MembraneExchanger
-    a :CellMembraneCurrent ;
+    a :CellMembraneCurrentRelated ;
     rdfs:label "Exchangers" ;
     rdfs:comment "Proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient." .
 
 :MembraneIonChannel
-    a :CellMembraneCurrent ;
+    a :CellMembraneCurrentRelated ;
     rdfs:label "Ion channels" ;
     rdfs:comment "Proteins allowing certain ions to flow down their electrochemical gradients." .
 
@@ -357,6 +367,7 @@
 :membrane_stimulus_current
     a :Annotation ;
     a :StimulusCurrent ;
+    a :IonicCurrent ;
     rdfs:label "Membrane stimulus current" .
 
 :membrane_stimulus_current_duration
@@ -550,6 +561,7 @@
 :membrane_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane potassium current" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
@@ -562,6 +574,7 @@
 :membrane_plateau_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane plateau potassium current" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
@@ -580,6 +593,7 @@
 :membrane_delayed_rectifier_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane delayed rectifier potassium current" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
@@ -622,6 +636,7 @@
 :membrane_slow_inward_current
     a :Annotation ;
     a :MembraneMixedChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane slow inward current" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
@@ -635,6 +650,7 @@
     a :Annotation ;
     a :MembraneMixedChannel ;
     a :PatchClampProperties ;
+    a :IonicCurrent ;
     rdfs:label "Membrane leakage current" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
@@ -655,6 +671,7 @@
 :membrane_fast_sodium_current
     a :Annotation ;
     a :MembraneSodiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane fast sodium current" .
 
 :membrane_fast_sodium_current_conductance
@@ -708,6 +725,7 @@
 :membrane_persistent_sodium_current
     a :Annotation ;
     a :MembraneSodiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane persistent sodium current" ;
     rdfs:comment "Also known as membrane late sodium current" .
 
@@ -727,6 +745,7 @@
 :membrane_background_sodium_current
     a :Annotation ;
     a :MembraneSodiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane background sodium current" .
 
 :membrane_background_sodium_current_conductance
@@ -743,6 +762,7 @@
 :membrane_rapid_delayed_rectifier_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane rapid delayed rectifier potassium current" .
 
 :membrane_rapid_delayed_rectifier_potassium_current_conductance
@@ -772,6 +792,7 @@
 :membrane_slow_delayed_rectifier_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane slow delayed rectifier potassium current" .
 
 :membrane_slow_delayed_rectifier_potassium_current_conductance
@@ -801,6 +822,7 @@
 :membrane_ultrarapid_delayed_rectifier_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane ultrarapid delayed rectifier potassium current" .
 
 :membrane_ultrarapid_delayed_rectifier_potassium_current_conductance
@@ -818,6 +840,7 @@
 :membrane_non_inactivating_steady_state_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane non-inactivating steady-state potassium current" .
 
 :membrane_non_inactivating_steady_state_potassium_current_conductance
@@ -829,6 +852,7 @@
 :membrane_inward_rectifier_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane inward rectifier potassium current" .
 
 :membrane_inward_rectifier_potassium_current_conductance
@@ -846,6 +870,7 @@
 :membrane_transient_outward_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:comment "I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)" ;
     rdfs:label "Membrane transient outward current" .
 
@@ -863,6 +888,7 @@
 :membrane_fast_transient_outward_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:comment "I_to fast is a potassium current, (a.k.a. I_to1 fast)" ;
     rdfs:label "Membrane fast transient outward current" .
 
@@ -885,6 +911,7 @@
 :membrane_slow_transient_outward_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:comment "I_to slow is a potassium current, (a.k.a. I_to1 slow)" ;
     rdfs:label "Membrane slow transient outward current" .
 
@@ -913,6 +940,7 @@
 :membrane_atp_dependent_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane ATP-dependent potassium current" .
 
 :membrane_atp_dependent_potassium_current_conductance
@@ -924,6 +952,7 @@
 :membrane_background_potassium_current
     a :Annotation ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane background potassium current" .
 
 :membrane_background_potassium_current_conductance
@@ -940,6 +969,7 @@
 :membrane_transient_outward_chloride_current
     a :Annotation ;
     a :MembraneChlorideChannel ;
+    a :IonicCurrent ;
     rdfs:comment "Calcium activated transient outward chloride current, commonly known as Ito2" ;
     rdfs:label "Membrane transient outward chloride current" .
 
@@ -953,6 +983,7 @@
 :membrane_background_chloride_current
     a :Annotation ;
     a :MembraneChlorideChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane background chloride current" .
 
 :membrane_background_chloride_current_conductance
@@ -970,6 +1001,7 @@
 :membrane_hyperpolarisation_activated_funny_current
     a :Annotation ;
     a :MembraneMixedChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane hyperpolarisation-activated funny current" .
 
 :membrane_hyperpolarisation_activated_funny_current_single_gate
@@ -1009,6 +1041,7 @@
     a :Annotation ;
     a :MembraneMixedChannel ;
     a :MembraneSodiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane L-type calcium channel sodium current" .
 
 :membrane_L_type_calcium_channel_sodium_current_conductance
@@ -1021,6 +1054,7 @@
     a :Annotation ;
     a :MembraneMixedChannel ;
     a :MembranePotassiumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane L-type calcium channel potassium current" .
 
 :membrane_L_type_calcium_channel_potassium_current_conductance
@@ -1037,6 +1071,7 @@
 :membrane_L_type_calcium_current
     a :Annotation ;
     a :MembraneCalciumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane L-type calcium current" .
 
 :membrane_L_type_calcium_current_conductance
@@ -1140,6 +1175,7 @@
 :membrane_background_calcium_current
     a :Annotation ;
     a :MembraneCalciumChannel ;
+    a :IonicCurrent ;
     rdfs:label "Membrane background calcium current" .
 
 :membrane_background_calcium_current_conductance
@@ -1154,6 +1190,7 @@
 :SR_release_current
     a :Annotation ;
     a :SRIonChannel ;
+    a :IonicCurrent ;
     rdfs:label "Sarcoplasmic reticulum release current" ;
     rdfs:comment "Also known as Jrel or RyR channel current" .
 
@@ -1165,6 +1202,7 @@
 :SR_uptake_current
     a :Annotation ;
     a :SRPump ;
+    a :IonicCurrent ;
     rdfs:label "Sarcoplasmic reticulum uptake current" ;
     rdfs:comment "Also known as Jup or SERCA current" .
 
@@ -1176,6 +1214,7 @@
 :SR_leak_current
     a :Annotation ;
     a :SRIonChannel ;
+    a :IonicCurrent ;
     rdfs:label "Sarcoplasmic reticulum leak current" .
 
 :SR_leak_current_max
@@ -1201,6 +1240,7 @@
 :membrane_sodium_calcium_exchanger_current
     a :Annotation ;
     a :MembraneExchanger ;
+    a :IonicCurrent ;
     rdfs:label "Membrane sodium-calcium exchanger current" .
 
 :membrane_sodium_calcium_exchanger_current_conductance
@@ -1218,6 +1258,7 @@
 :membrane_sodium_calcium_exchanger_dyadic_space_current
     a :Annotation ;
     a :MembraneExchanger ;
+    a :IonicCurrent ;
     rdfs:comment "NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR)." ;
     rdfs:label "Sodium-calcium exchanger current into dyadic space" .
 
@@ -1231,6 +1272,7 @@
 :membrane_sodium_potassium_pump_current
     a :Annotation ;
     a :MembranePump ;
+    a :IonicCurrent ;
     rdfs:label "Membrane sodium-potassium pump current" .
 
 :membrane_sodium_potassium_pump_current_permeability
@@ -1243,6 +1285,7 @@
 :membrane_calcium_pump_current
     a :Annotation ;
     a :MembranePump ;
+    a :IonicCurrent ;
     rdfs:label "Membrane calcium pump current" .
 
 :membrane_calcium_pump_current_conductance
@@ -1255,6 +1298,7 @@
 :membrane_potassium_pump_current
     a :Annotation ;
     a :MembranePump ;
+    a :IonicCurrent ;
     rdfs:label "Membrane potassium pump current" .
 
 :membrane_potassium_pump_current_conductance

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -170,33 +170,33 @@
 
 :MembraneExchangerRelated
     a :CellMembraneCurrentRelated ;
-    rdfs:label "Exchangers" ;
+    rdfs:label "Exchanger" ;
     rdfs:comment "Terms related to proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient." .
 
-:MembraneIonChannel
+:MembraneIonChannelRelated
     a :CellMembraneCurrentRelated ;
     rdfs:label "Ion channels" ;
     rdfs:comment "Terms related to proteins allowing certain ions to flow down their electrochemical gradients." .
 
-:MembranePotassiumChannel
-    a :MembraneIonChannel ;
-    rdfs:label "Potassium ion channels" .
+:MembranePotassiumChannelRelated
+    a :MembraneIonChannelRelated ;
+    rdfs:label "Terms related to potassium ion channels" .
 
-:MembraneSodiumChannel
-    a :MembraneIonChannel ;
-    rdfs:label "Sodium ion channels" .
+:MembraneSodiumChannelRelated
+    a :MembraneIonChannelRelated ;
+    rdfs:label "Terms related to sodium ion channels" .
 
-:MembraneCalciumChannel
-    a :MembraneIonChannel ;
-    rdfs:label "Calcium ion channels" .
+:MembraneCalciumChannelRelated
+    a :MembraneIonChannelRelated ;
+    rdfs:label "Terms related to calcium ion channels" .
 
-:MembraneChlorideChannel
-    a :MembraneIonChannel ;
-    rdfs:label "Chloride ion channels" .
+:MembraneChlorideChannelRelated
+    a :MembraneIonChannelRelated ;
+    rdfs:label "Terms related to chloride ion channels" .
 
-:MembraneMixedChannel
-    a :MembraneIonChannel ;
-    rdfs:label "Mixed ion channels" ;
+:MembraneMixedChannelRelated
+    a :MembraneIonChannelRelated ;
+    rdfs:label "terms related to mixed ion channels" ;
     rdfs:comment "Membrane ion channels that don't fit a more specific categorisation, or transport multiple species." .
 
 :PatchClampProperties
@@ -204,22 +204,22 @@
     rdfs:label "Patch clamp properties" ;
     rdfs:comment "Properties of the patch clamp experimental setup represented explicitly in models." .
 
-:SRCurrent
+:SRCurrentRelated
     a :Category ;
     rdfs:label "SR currents" ;
     rdfs:comment "Annotations associated with currents across the sarcoplasmic reticulum membrane." .
 
-:SRPump
-    a :SRCurrent ;
-    rdfs:label "Pumps" .
+:SRPumpRelatedRelated
+    a :SRCurrentRelated ;
+    rdfs:label "Terms related to pumps" .
 
-:SRExchanger
-    a :SRCurrent ;
+:SRExchangerRelated
+    a :SRCurrentRelated ;
     rdfs:label "Exchangers" .
 
-:SRIonChannel
-    a :SRCurrent ;
-    rdfs:label "Ion channels" .
+:SRIonChannelRelatedRelated
+    a :SRCurrentRelated ;
+    rdfs:label "Terms related to ion channels" .
 
 :Concentration
     a :Category ;
@@ -308,42 +308,42 @@
 # introduced for SR membrane, mitochondrial membranes etc.
 :sodium_reversal_potential
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     a :Concentration ;
     rdfs:label "Sodium reversal potential" ;
     rdfs:comment "Reversal potential of sodium ions across the cell membrane" .
 
 :potassium_reversal_potential
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :Concentration ;
     rdfs:label "Potassium reversal potential" ;
     rdfs:comment "Reversal potential of potassium ions across the cell membrane" .
 
 :rapid_delayed_rectifier_potassium_reversal_potential
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :Concentration ;
     rdfs:label "IKr reversal potential" ;
     rdfs:comment "Reversal potential for the IKr current across the cell membrane, for when it isn't the general potassium_reversal_potential" .
 
 :slow_delayed_rectifier_potassium_reversal_potential
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :Concentration ;
     rdfs:label "IKs reversal potential" ;
     rdfs:comment "Reversal potential for the IKs current across the cell membrane, for when it isn't the general potassium_reversal_potential" .
 
 :calcium_reversal_potential
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     a :Concentration ;
     rdfs:label "Calcium reversal potential" ;
     rdfs:comment "Reversal potential of calcium ions across the cell membrane" .
 
 :chloride_reversal_potential
     a :Annotation ;
-    a :MembraneChlorideChannel ;
+    a :MembraneChlorideChannelRelated ;
     a :Concentration ;
     rdfs:label "Chloride reversal potential" ;
     rdfs:comment "Reversal potential of chloride ions across the cell membrane" .
@@ -555,95 +555,95 @@
 # HISTORIC metadata - only for early models lacking components.
 :membrane_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane potassium current" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :membrane_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane potassium current conductance" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :membrane_plateau_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane plateau potassium current" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :membrane_plateau_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane plateau potassium current conductance" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :potassium_channel_n_gate
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Potassium channel n gate" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :membrane_delayed_rectifier_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane delayed rectifier potassium current" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :membrane_delayed_rectifier_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane delayed rectifier potassium current conductance" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :rapid_time_dependent_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Rapid time-dependent potassium current conductance" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :rapid_time_dependent_potassium_current_Xr1_gate
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Rapid time-dependent potassium current Xr1 gate" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :rapid_time_dependent_potassium_current_Xr2_gate
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Rapid time-dependent potassium current Xr2 gate" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :slow_time_dependent_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Slow time-dependent potassium current conductance" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :slow_time_dependent_potassium_current_Xs_gate
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Slow time-dependent potassium current Xs gate" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :membrane_slow_inward_current
     a :Annotation ;
-    a :MembraneMixedChannel ;
+    a :MembraneMixedChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane slow inward current" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :membrane_slow_inward_current_conductance
     a :Annotation ;
-    a :MembraneMixedChannel ;
+    a :MembraneMixedChannelRelated ;
     rdfs:label "Membrane slow inward current conductance" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
 
 :membrane_leakage_current
     a :Annotation ;
-    a :MembraneMixedChannel ;
+    a :MembraneMixedChannelRelated ;
     a :PatchClampProperties ;
     a :IonicCurrent ;
     rdfs:label "Membrane leakage current" ;
@@ -651,7 +651,7 @@
 
 :membrane_leakage_current_conductance
     a :Annotation ;
-    a :MembraneMixedChannel ;
+    a :MembraneMixedChannelRelated ;
     a :PatchClampProperties ;
     rdfs:label "Membrane leakage current conductance" ;
     rdfs:comment "Historical metadata - only for early models lacking components." .
@@ -665,87 +665,87 @@
 # I Na (fast)
 :membrane_fast_sodium_current
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane fast sodium current" .
 
 :membrane_fast_sodium_current_conductance
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane fast sodium current conductance" .
 
 :membrane_fast_sodium_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane fast sodium current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_fast_sodium_current_m_gate
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane fast sodium current m gate" .
 
 :membrane_fast_sodium_current_h_gate
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane fast sodium current h gate" .
 
 :membrane_fast_sodium_current_h_gate_tau
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane fast sodium current h gate tau" .
 
 :membrane_fast_sodium_current_j_gate
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane fast sodium current j gate" .
 
 :membrane_fast_sodium_current_j_gate_tau
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane fast sodium current j gate tau" .
 
 :membrane_fast_sodium_current_shift_inactivation
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane fast sodium current shift inactivation" .
 
 :membrane_fast_sodium_current_reduced_inactivation
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane fast sodium current reduced inactivation" .
 
 
 # I_Na_L (late or persistent)
 :membrane_persistent_sodium_current
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane persistent sodium current" ;
     rdfs:comment "Also known as membrane late sodium current" .
 
 :membrane_persistent_sodium_current_conductance
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane persistent sodium current conductance" ;
     rdfs:comment "Also known as membrane late sodium current conductance" .
 
 :membrane_persistent_sodium_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane persistent sodium current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 # I Na,b (background)
 :membrane_background_sodium_current
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane background sodium current" .
 
 :membrane_background_sodium_current_conductance
     a :Annotation ;
-    a :MembraneSodiumChannel ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane background sodium current conductance" .
 
 
@@ -756,203 +756,203 @@
 # I Kr
 :membrane_rapid_delayed_rectifier_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane rapid delayed rectifier potassium current" .
 
 :membrane_rapid_delayed_rectifier_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane rapid delayed rectifier potassium current conductance" .
 
 :membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane rapid delayed rectifier potassium current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_rapid_delayed_rectifier_potassium_current_conductance1
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane rapid delayed rectifier potassium current conductance 1" ;
     rdfs:comment "TODO!" .
 
 :membrane_rapid_delayed_rectifier_potassium_current_conductance2
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane rapid delayed rectifier potassium current conductance 2" ;
     rdfs:comment "TODO!" .
 
 # I Ks
 :membrane_slow_delayed_rectifier_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane slow delayed rectifier potassium current" .
 
 :membrane_slow_delayed_rectifier_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane slow delayed rectifier potassium current conductance" .
 
 :membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane slow delayed rectifier potassium current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane slow delayed rectifier potassium current xs1 gate tau" ;
     rdfs:comment "Really a scaling factor for tau" .
 
 :membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane slow delayed rectifier potassium current xs2 gate tau" ;
     rdfs:comment "Really a scaling factor for tau" .
 
 # I_Kur
 :membrane_ultrarapid_delayed_rectifier_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane ultrarapid delayed rectifier potassium current" .
 
 :membrane_ultrarapid_delayed_rectifier_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane ultrarapid delayed rectifier potassium current conductance" .
 
 :membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane ultrarapid delayed rectifier potassium current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 # I_Kss or Iss
 :membrane_non_inactivating_steady_state_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane non-inactivating steady-state potassium current" .
 
 :membrane_non_inactivating_steady_state_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane non-inactivating steady-state potassium current conductance" .
 
 # I K1
 :membrane_inward_rectifier_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane inward rectifier potassium current" .
 
 :membrane_inward_rectifier_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane inward rectifier potassium current conductance" .
 
 :membrane_inward_rectifier_potassium_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane inward rectifier potassium current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 # I to, (a.k.a. I_to1) sometimes fast and slow components, sometimes not.
 :membrane_transient_outward_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:comment "I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)" ;
     rdfs:label "Membrane transient outward current" .
 
 :membrane_transient_outward_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane transient outward current conductance" .
 
 :membrane_transient_outward_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane transient outward current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_fast_transient_outward_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:comment "I_to fast is a potassium current, (a.k.a. I_to1 fast)" ;
     rdfs:label "Membrane fast transient outward current" .
 
 :membrane_transient_outward_current_r_gate
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane transient outward current r gate" .
 
 :membrane_fast_transient_outward_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane fast transient outward current conductance" .
 
 :membrane_fast_transient_outward_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane fast transient outward current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_slow_transient_outward_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:comment "I_to slow is a potassium current, (a.k.a. I_to1 slow)" ;
     rdfs:label "Membrane slow transient outward current" .
 
 :membrane_transient_outward_current_s_gate
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane transient outward current s gate" .
 
 :membrane_slow_transient_outward_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane slow transient outward current conductance" .
 
 :membrane_slow_transient_outward_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane slow transient outward current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_transient_outward_current_time_independent_rectification_gate_constant
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane transient outward current time-independent rectification gate constant" .
 
 # I katp
 :membrane_atp_dependent_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane ATP-dependent potassium current" .
 
 :membrane_atp_dependent_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane ATP-dependent potassium current conductance" .
 
 # I K,b (background current / leak)
 :membrane_background_potassium_current
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane background potassium current" .
 
 :membrane_background_potassium_current_conductance
     a :Annotation ;
-    a :MembranePotassiumChannel ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane background potassium current conductance" .
 
 
@@ -963,27 +963,27 @@
 # Ito,2 or Ito2
 :membrane_transient_outward_chloride_current
     a :Annotation ;
-    a :MembraneChlorideChannel ;
+    a :MembraneChlorideChannelRelated ;
     a :IonicCurrent ;
     rdfs:comment "Calcium activated transient outward chloride current, commonly known as Ito2" ;
     rdfs:label "Membrane transient outward chloride current" .
 
 :membrane_transient_outward_chloride_current_conductance
     a :Annotation ;
-    a :MembraneChlorideChannel ;
+    a :MembraneChlorideChannelRelated ;
     rdfs:label "Membrane transient outward chloride current conductance" .
 
 
 # I Cl,b (background)
 :membrane_background_chloride_current
     a :Annotation ;
-    a :MembraneChlorideChannel ;
+    a :MembraneChlorideChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane background chloride current" .
 
 :membrane_background_chloride_current_conductance
     a :Annotation ;
-    a :MembraneChlorideChannel ;
+    a :MembraneChlorideChannelRelated ;
     rdfs:label "Membrane background chloride current conductance" .
 
 # ========================================================================
@@ -995,37 +995,37 @@
 # if it isn't try and figure out which ionic species is being modelled for tagging, and give two tags if necessary.
 :membrane_hyperpolarisation_activated_funny_current
     a :Annotation ;
-    a :MembraneMixedChannel ;
+    a :MembraneMixedChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane hyperpolarisation-activated funny current" .
 
 :membrane_hyperpolarisation_activated_funny_current_single_gate
     a :Annotation ;
-    a :MembraneMixedChannel ;
+    a :MembraneMixedChannelRelated ;
     rdfs:label "Membrane hyperpolarisation-activated funny current single gate" .
 
 :membrane_hyperpolarisation_activated_funny_current_potassium_component
     a :Annotation ;
-    a :MembraneMixedChannel ;
-    a :MembranePotassiumChannel ;
+    a :MembraneMixedChannelRelated ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane hyperpolarisation-activated funny current potassium component" .
 
 :membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance
     a :Annotation ;
-    a :MembraneMixedChannel ;
-    a :MembranePotassiumChannel ;
+    a :MembraneMixedChannelRelated ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane hyperpolarisation-activated funny current potassium component conductance" .
 
 :membrane_hyperpolarisation_activated_funny_current_sodium_component
     a :Annotation ;
-    a :MembraneMixedChannel ;
-    a :MembraneSodiumChannel ;
+    a :MembraneMixedChannelRelated ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane hyperpolarisation-activated funny current sodium component" .
 
 :membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance
     a :Annotation ;
-    a :MembraneMixedChannel ;
-    a :MembraneSodiumChannel ;
+    a :MembraneMixedChannelRelated ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane hyperpolarisation-activated funny current sodium component conductance" .
 
 # ICaL conductance of non-calcium ions:
@@ -1034,28 +1034,28 @@
 # scale all these as well, or are they treated as completely separate ion currents (as per O'Hara).
 :membrane_L_type_calcium_channel_sodium_current
     a :Annotation ;
-    a :MembraneMixedChannel ;
-    a :MembraneSodiumChannel ;
+    a :MembraneMixedChannelRelated ;
+    a :MembraneSodiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane L-type calcium channel sodium current" .
 
 :membrane_L_type_calcium_channel_sodium_current_conductance
     a :Annotation ;
-    a :MembraneMixedChannel ;
-    a :MembraneSodiumChannel ;
+    a :MembraneMixedChannelRelated ;
+    a :MembraneSodiumChannelRelated ;
     rdfs:label "Membrane L-type calcium channel sodium current conductance or permeability" .
 
 :membrane_L_type_calcium_channel_potassium_current
     a :Annotation ;
-    a :MembraneMixedChannel ;
-    a :MembranePotassiumChannel ;
+    a :MembraneMixedChannelRelated ;
+    a :MembranePotassiumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane L-type calcium channel potassium current" .
 
 :membrane_L_type_calcium_channel_potassium_current_conductance
     a :Annotation ;
-    a :MembraneMixedChannel ;
-    a :MembranePotassiumChannel ;
+    a :MembraneMixedChannelRelated ;
+    a :MembranePotassiumChannelRelated ;
     rdfs:label "Membrane L-type calcium channel potassium current conductance" .
 
 
@@ -1065,117 +1065,117 @@
 # I CaL
 :membrane_L_type_calcium_current
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane L-type calcium current" .
 
 :membrane_L_type_calcium_current_conductance
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current conductance" .
 
 :membrane_L_type_calcium_current_open_probability
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current open probability" .
 
 :membrane_L_type_calcium_current_driving_term
-    a :MembraneCalciumChannel ;    
+    a :MembraneCalciumChannelRelated ;    
     rdfs:label "Membrane L-type calcium current driving term (GHK or ohmic)" .
 
 :membrane_L_type_calcium_current_ohmic_driving_term
     a :Annotation ;
-    a :MembraneCalciumChannel ; 
+    a :MembraneCalciumChannelRelated ; 
     a :membrane_L_type_calcium_current_driving_term ;
     rdfs:label "Membrane L-type calcium current Ohmic driving term" .
 
 :membrane_L_type_calcium_current_GHK_driving_term
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     a :membrane_L_type_calcium_current_driving_term ;
     rdfs:label "Membrane L-type calcium current GHK driving term" .
 
 :membrane_L_type_calcium_current_conductance_scaling_factor
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current conductance scaling factor" ;
     rdfs:comment "A scalar that multiplies the conductance term for this current" .
 
 :membrane_L_type_calcium_current_d_gate
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current d gate" .
 
 :membrane_L_type_calcium_current_f_gate
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current f gate" .
 
 :membrane_L_type_calcium_current_fCass_gate
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current fCass gate" .
 
 :membrane_L_type_calcium_current_fCa_gate
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current fCa gate" .
 
 :membrane_L_type_calcium_current_fCa2_gate
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current fCa2 gate" .
 
 :membrane_L_type_calcium_current_f2_gate
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current f2 gate" .
 
 :membrane_L_type_calcium_current_f2ds_gate
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current f2ds gate" .
 
 :membrane_L_type_calcium_current_d2_gate
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current d2 gate" .
 
 :membrane_L_type_calcium_current_f_gate_tau
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current f gate" .
 
 :membrane_L_type_calcium_current_f2_gate_tau
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current f2 gate" .
 
 :membrane_L_type_calcium_current_fCa_gate_tau
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current fCa gate tag" .
 
 :membrane_L_type_calcium_current_fCa2_gate_tau
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current fCa2 gate tau" .
 
 :membrane_L_type_calcium_current_d_gate_power_tau
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane L-type calcium current d gate power tau" .
 
 # I Ca,b (background)
 :membrane_background_calcium_current
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane background calcium current" .
 
 :membrane_background_calcium_current_conductance
     a :Annotation ;
-    a :MembraneCalciumChannel ;
+    a :MembraneCalciumChannelRelated ;
     rdfs:label "Membrane background calcium current conductance" .
 
 # ========================================================================
@@ -1184,47 +1184,47 @@
 
 :SR_release_current
     a :Annotation ;
-    a :SRIonChannel ;
+    a :SRIonChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Sarcoplasmic reticulum release current" ;
     rdfs:comment "Also known as Jrel or RyR channel current" .
 
 :SR_release_current_max
     a :Annotation ;
-    a :SRIonChannel ;
+    a :SRIonChannelRelated ;
     rdfs:label "Sarcoplasmic reticulum release current max" .
 
 :SR_uptake_current
     a :Annotation ;
-    a :SRPump ;
+    a :SRPumpRelated ;
     a :IonicCurrent ;
     rdfs:label "Sarcoplasmic reticulum uptake current" ;
     rdfs:comment "Also known as Jup or SERCA current" .
 
 :SR_uptake_current_max
     a :Annotation ;
-    a :SRPump ;
+    a :SRPumpRelated ;
     rdfs:label "Sarcoplasmic reticulum uptake current max" .
 
 :SR_leak_current
     a :Annotation ;
-    a :SRIonChannel ;
+    a :SRIonChannelRelated ;
     a :IonicCurrent ;
     rdfs:label "Sarcoplasmic reticulum leak current" .
 
 :SR_leak_current_max
     a :Annotation ;
-    a :SRIonChannel ;
+    a :SRIonChannelRelated ;
     rdfs:label "Sarcoplasmic reticulum leak current max" .
 
 :SR_release_kmcacyt
     a :Annotation ;
-    a :SRIonChannel ;
+    a :SRIonChannelRelated ;
     rdfs:label "Sarcoplasmic reticulum release kmcacyt" .
 
 :SR_release_kmcads
     a :Annotation ;
-    a :SRIonChannel ;
+    a :SRIonChannelRelated ;
     rdfs:label "Sarcoplasmic reticulum release kmcads" .
 
 # ========================================================================

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -211,7 +211,8 @@
 
 :SRPumpRelatedRelated
     a :SRCurrentRelated ;
-    rdfs:label "Terms related to pumps" .
+    rdfs:label "Pumps"  ;
+    rdfs:comment "Terms related to proteins in the sarcoplasmic reticulum membrane that use energy in ATP to pump ions against their electrochemical gradients." .
 
 :SRExchangerRelated
     a :SRCurrentRelated ;

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -148,30 +148,25 @@
     a :Category ;
     rdfs:label "Physical properties" .
 
-:IonicCurrent:
-    a :Category ;
-    rdfs:label "Ion currents" ;
-    rdfs:comment "Annotations of any kind of currents." .
+:IonicCurrent
+    a rdfs:Class ;
+    rdfs:label "Ionic currents" ;
+    rdfs:comment "All terms that represent a current anywhere in the cell." .
 
 :CellMembraneCurrentRelated
     a :Category ;
-    rdfs:label "Membrane currents" ;
-    rdfs:comment "Annotations associated with currents across the cell membrane." .
-
-:CellMembraneCurrentRelated
-    a :Category ;
-    rdfs:label "Membrane currents" ;
+    rdfs:label "Membrane currents and their properties" ;
     rdfs:comment "Annotations associated with currents across the cell membrane." .
 
 :StimulusCurrent
     a :CellMembraneCurrentRelated ;
     a :ChasteMetadata ;
-    rdfs:label "Stimulus current properties" .
+    rdfs:label "Stimulus current and its properties" .
 
-:MembranePump
+:MembranePumpRelated
     a :CellMembraneCurrentRelated ;
     rdfs:label "Pumps" ;
-    rdfs:comment "Proteins that use energy in ATP to pump ions against their electrochemical gradients." .
+    rdfs:comment "Terms related to proteins that use energy in ATP to pump ions against their electrochemical gradients." .
 
 :MembraneExchanger
     a :CellMembraneCurrentRelated ;
@@ -366,34 +361,34 @@
 
 :membrane_stimulus_current
     a :Annotation ;
-    a :StimulusCurrent ;
+    a :StimulusCurrentRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane stimulus current" .
 
 :membrane_stimulus_current_duration
     a :Annotation ;
-    a :StimulusCurrent ;
+    a :StimulusCurrentRelated ;
     rdfs:label "Membrane stimulus current pulse duration" .
 
 :membrane_stimulus_current_amplitude
     a :Annotation ;
-    a :StimulusCurrent ;
+    a :StimulusCurrentRelated ;
     rdfs:label "Membrane stimulus current pulse amplitude" ;
     rdfs:comment "This should be negative in order to cause a positive change in voltage." .
 
 :membrane_stimulus_current_period
     a :Annotation ;
-    a :StimulusCurrent ;
+    a :StimulusCurrentRelated ;
     rdfs:label "Membrane stimulus current pulse period" .
 
 :membrane_stimulus_current_offset
     a :Annotation ;
-    a :StimulusCurrent ;
+    a :StimulusCurrentRelated ;
     rdfs:label "Membrane stimulus current pulse start offset" .
 
 :membrane_stimulus_current_end
     a :Annotation ;
-    a :StimulusCurrent ;
+    a :StimulusCurrentRelated ;
     rdfs:label "Membrane stimulus current pulse end time" .
 
 # =====================================================
@@ -1271,39 +1266,39 @@
 # INaK
 :membrane_sodium_potassium_pump_current
     a :Annotation ;
-    a :MembranePump ;
+    a :MembranePumpRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane sodium-potassium pump current" .
 
 :membrane_sodium_potassium_pump_current_permeability
     a :Annotation ;
-    a :MembranePump ;
+    a :MembranePumpRelated ;
     rdfs:label "Membrane sodium-potassium pump current permeability" ;
     rdfs:comment "Often known as INaK_max" .
 
 # Ip,Ca
 :membrane_calcium_pump_current
     a :Annotation ;
-    a :MembranePump ;
+    a :MembranePumpRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane calcium pump current" .
 
 :membrane_calcium_pump_current_conductance
     a :Annotation ;
-    a :MembranePump ;
+    a :MembranePumpRelated ;
     rdfs:label "Membrane calcium pump current conductance" ;
     rdfs:comment "Also known as permeability" .
 
 # Ip,K
 :membrane_potassium_pump_current
     a :Annotation ;
-    a :MembranePump ;
+    a :MembranePumpRelated ;
     a :IonicCurrent ;
     rdfs:label "Membrane potassium pump current" .
 
 :membrane_potassium_pump_current_conductance
     a :Annotation ;
-    a :MembranePump ;
+    a :MembranePumpRelated ;
     rdfs:label "Membrane potassium pump current conductance" ;
     rdfs:comment "Also known as permeability" .
 

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -196,7 +196,7 @@
 
 :MembraneMixedChannelRelated
     a :MembraneIonChannelRelated ;
-    rdfs:label "terms related to mixed ion channels" ;
+    rdfs:label "Terms related to mixed ion channels" ;
     rdfs:comment "Membrane ion channels that don't fit a more specific categorisation, or transport multiple species." .
 
 :PatchClampProperties

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -218,9 +218,10 @@
     a :SRCurrentRelated ;
     rdfs:label "Exchangers" .
 
-:SRIonChannelRelatedRelated
+:SRIonChannelRelated
     a :SRCurrentRelated ;
-    rdfs:label "Terms related to ion channels" .
+    rdfs:label "Ion channels" ;
+    rdfs:comment "Terms related to proteins in the sarcoplasmic reticulum membrane allowing certain ions to flow down their electrochemical gradients." .
 
 :Concentration
     a :Category ;

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -170,7 +170,7 @@
 
 :MembraneExchangerRelated
     a :CellMembraneCurrentRelated ;
-    rdfs:label "Exchanger" ;
+    rdfs:label "Exchangers" ;
     rdfs:comment "Terms related to proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient." .
 
 :MembraneIonChannelRelated


### PR DESCRIPTION
For chaste code generation we needed a way to differentiate between membrane currents and their properties that are not actually currents themselves, so that we can create derived quantities in chaste units for just the currents without inadvertently converting their properties.