### PR TITLE
Restore stimulus current properties in the annotator

### DIFF
--- a/oxford-metadata.rdf
+++ b/oxford-metadata.rdf
@@ -4,29 +4,1206 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 >
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#bath_potassium_concentration">
+    <rdfs:label>Concentration of potassium in the bath</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:comment>TODO!</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_chloride_concentration">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Basic Chaste metadata</rdfs:label>
+    <rdfs:comment>Core annotations needed for a model to work well with the Chaste simulator.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance_scaling_factor">
+    <rdfs:label>Membrane transient outward current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Universal constants</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
     <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:label>Concentration of chloride ions in the sub-membrane compartment</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane plateau potassium current</rdfs:label>
+    <rdfs:label>Membrane stimulus current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_a_parameter">
+    <rdfs:label>'a' parameter in a transition rate of the form a*exp(±b*V)</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>'a' parameter in a transition rate with linear voltage dependence, of the form a*exp(±b*V)</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset">
+    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
+    <rdfs:label>Buffering</rdfs:label>
+    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current">
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdfs:label>Membrane leakage current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+    <rdfs:label>Concentration of calcium ions in the sub-membrane compartment</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane leakage current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane background sodium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
+    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Potassium channel n gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchangerRelated">
+    <rdfs:label>Exchangers</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_open_probability">
+    <rdfs:label>Membrane L-type calcium current open probability</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
+    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
+    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane fast transient outward current</rdfs:label>
+    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
+    <rdfs:label>Mammalian</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_V_positive_rate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Transition rate k of the form k=a*exp(+b*V)</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate"/>
+    <rdfs:comment>Transition rate k with positive linear voltage dependence of the form k=a*exp(+b*V)</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:label>Terms related to sodium ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
+    <rdfs:label>Membrane persistent sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Cytosolic ionic concentrations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Cell membrane capacitance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdfs:label>Membrane potassium pump current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
   </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated">
+    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
+    <rdfs:label>Membrane currents and their properties</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane background chloride current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
+    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
+    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
+    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Species</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
+    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_chloride_concentration">
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Concentration of chloride ions in the sub-membrane compartment</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#epicardial">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>(Sub)epicardial</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>TODO!</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time">
+    <rdfs:comment>The independent variable, the simulation time.</rdfs:comment>
+    <rdfs:label>Time</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current h gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
+    <rdfs:label>Physical properties</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane calcium pump current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
+    <rdfs:label>Membrane background potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated"/>
+    <rdfs:label>Parameters for transition rate equations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
+    <rdfs:label>Chloride reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate">
+    <rdfs:label>Ion channel state transition rate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term">
+    <rdfs:label>Membrane L-type calcium current driving term (GHK or ohmic)</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane L-type calcium channel sodium current conductance or permeability</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>A maximal conductance or permeability parameter</rdfs:label>
+    <rdfs:comment>Tags for maximal conductance or permeability when open probability is equal to one (these may be algebraic expressions as well as constants).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated">
+    <rdfs:label>Pumps</rdfs:label>
+    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
+    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Potassium reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated">
+    <rdfs:comment>Terms related to proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:label>Exchangers</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Membrane slow inward current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:label>Terms related to chloride ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
+    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>SR currents</rdfs:label>
+    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
+    <rdfs:label>State variable</rdfs:label>
+    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#seal_resistance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Patch clamp seal resistance</rdfs:label>
+    <rdfs:comment>Patch clamp seal resistance</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:comment>Often known as INaK_max</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdfs:comment>NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR).</rdfs:comment>
+    <rdfs:label>Sodium-calcium exchanger current into dyadic space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dog">
+    <rdfs:label>Dog</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
+    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current j gate tau</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sodium_reversal_potential">
+    <rdfs:label>Sodium reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:comment>Reversal potential of sodium ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
+    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
+    <rdfs:label>A category of annotations</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
+    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
+    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_b_parameter">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>'b' parameter in a transition rate with linear voltage dependence, of the form a*exp(±b*V)</rdfs:comment>
+    <rdfs:label>'b' parameter in a transition rate of the form a*exp(±b*V)</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Calcium reversal potential</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
+    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular potassium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
+    <rdfs:label>The value of a measured quantity</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
+    <rdfs:label>Faraday's constant - F</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_GHK_driving_term">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
+    <rdfs:label>Membrane L-type calcium current GHK driving term</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_delayed_rectifier_potassium_reversal_potential">
+    <rdfs:comment>Reversal potential for the IKr current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
+    <rdfs:label>IKr reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period">
+    <rdfs:label>Membrane stimulus current pulse period</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated">
+    <rdfs:label>Stimulus current and its properties</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane background calcium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
+    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>The units of a measured quantity</rdfs:label>
+    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
+    <rdfs:label>Membrane transient outward current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
+    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane background sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Ventricular</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_r_gate">
+    <rdfs:label>Membrane transient outward current r gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#endocardial">
+    <rdfs:label>(Sub)endocardial</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Cytosolic chloride concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
+    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
+    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance_scaling_factor">
+    <rdfs:label>Membrane slow transient outward current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
+    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#right_ventricular">
+    <rdfs:label>Right ventricular</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:label>Pumps</rdfs:label>
+    <rdfs:comment>Terms related to proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CustomAnnotations">
+    <rdfs:comment>Custom annotations in other namespaces referenced by protocols.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Custom annotations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdfs:label>Membrane inward rectifier potassium current conductance scaling factor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
+    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
+    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane slow transient outward current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_V_negative_rate">
+    <rdfs:label>Transition rate k of the form k=a*exp(-b*V)</rdfs:label>
+    <rdfs:comment>Transition rate k with negative linear voltage dependence of the form k=a*exp(-b*V)</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated">
+    <rdfs:label>Transition rates and related parameters</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
+    <rdfs:label>Terms related to mixed ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_delayed_rectifier_potassium_reversal_potential">
+    <rdfs:comment>Reversal potential for the IKs current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>IKs reversal potential</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate">
+    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#concentration_clamp_onoff">
+    <rdfs:comment>Deprecated</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sino_atrial_node">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Sino-atrial node</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
+    <rdfs:label>Temperature measurement</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
+    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdfs:label>Membrane L-type calcium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed">
+    <rdfs:comment>This indicates to the annotation tool that it should allow multiple occurrences.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Annotations that can appear on more than one variable in a model.</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
+    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance_scaling_factor">
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdfs:label>Membrane persistent sodium current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Voltage across the cell membrane</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:comment>Terms related to proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
+    <rdfs:label>Ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated">
+    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
+    <rdfs:label>Ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Extracellular calcium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Ionic concentrations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Temperature</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#atrial">
+    <rdfs:label>Atrial</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
+    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated">
+    <rdfs:label>Terms related to calcium ion channels</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
+    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Patch clamp properties</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
+    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Ionic currents</rdfs:label>
+    <rdfs:comment>All terms that represent a current anywhere in the cell.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
+    <rdfs:label>Left ventricular</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
+    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Cell type</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane fast transient outward current conductance scaling factor</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdfs:label>Membrane plateau potassium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
+    <rdfs:label>Variable Annotation</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Ionic concentrations in the SR</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
+    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
+    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
+    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_ohmic_driving_term">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current Ohmic driving term</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
+    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current conductance scaling factor</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated">
+    <rdfs:label>Terms related to potassium ion channels</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
+    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
+    <rdfs:label>Membrane L-type calcium current</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current_conductance">
+    <rdfs:label>Membrane transient outward chloride current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
+    <rdfs:label>Extracellular chloride concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>TODO!</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
+    <rdfs:label>Extracellular sodium concentration</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+  </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata">
-    <dcterms:abstract>Chaste metadata for annotating CellML files representing cardiac electrophysiology models.</dcterms:abstract>
-    <dcterms:creator>Chaste Development Team</dcterms:creator>
     <dcterms:license>Copyright (c) 2005-2020, University of Oxford.
 All rights reserved.
 
@@ -58,1242 +1235,65 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </dcterms:license>
+    <dcterms:abstract>Chaste metadata for annotating CellML files representing cardiac electrophysiology models.</dcterms:abstract>
+    <dcterms:creator>Chaste Development Team</dcterms:creator>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rabbit">
+    <rdfs:label>Rabbit</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_V_positive_rate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Transition rate k with positive linear voltage dependence of the form k=a*exp(+b*V)</rdfs:comment>
-    <rdfs:label>Transition rate k of the form k=a*exp(+b*V)</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance_scaling_factor">
-    <rdfs:label>Membrane fast transient outward current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane leakage current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_delayed_rectifier_potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:comment>Reversal potential for the IKs current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
-    <rdfs:label>IKs reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane slow transient outward current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
-    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current">
-    <rdfs:label>Membrane background calcium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
-    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
-    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated"/>
-    <rdfs:label>Parameters for transition rate equations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane leakage current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
-    <rdfs:comment>TODO!</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-    <rdfs:label>Terms related to chloride ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Species</rdfs:label>
-    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
-    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata">
-    <rdfs:comment>Core annotations needed for a model to work well with the Chaste simulator.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Basic Chaste metadata</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#NSR_calcium_concentration">
-    <rdfs:comment>The network SR is the non-junctional part of the SR.</rdfs:comment>
-    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane fast sodium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current conductance or permeability</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane background sodium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#seal_resistance">
-    <rdfs:comment>Patch clamp seal resistance</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Patch clamp seal resistance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_ohmic_driving_term">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current Ohmic driving term</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdfs:label>Cell membrane capacitance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
-    <rdfs:label>Variable Annotation</rdfs:label>
-    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane stimulus current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate">
-    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>Tags for maximal conductance or permeability when open probability is equal to one (these may be algebraic expressions as well as constants).</rdfs:comment>
-    <rdfs:label>A maximal conductance or permeability parameter</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Extracellular sodium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#bath_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>TODO!</rdfs:comment>
-    <rdfs:label>Concentration of potassium in the bath</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
-    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
-    <rdfs:label>Faraday's constant - F</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sino_atrial_node">
-    <rdfs:label>Sino-atrial node</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
-    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
-    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
-    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
-    <rdfs:label>Calcium reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
-    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdfs:label>Membrane slow transient outward current conductance scaling factor</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane potassium pump current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
-    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current h gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#endocardial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>(Sub)endocardial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
-    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_b_parameter">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>'b' parameter in a transition rate of the form a*exp(±b*V)</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
-    <rdfs:comment>'b' parameter in a transition rate with linear voltage dependence, of the form a*exp(±b*V)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
-    <rdfs:label>Membrane fast transient outward current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane L-type calcium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
-    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
-    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
-    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
-    <rdfs:label>Buffering</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
-    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Temperature</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
-    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Cytosolic ionic concentrations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdfs:label>Pumps</rdfs:label>
-    <rdfs:comment>Terms related to proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular potassium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
-    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:comment>Often known as INaK_max</rdfs:comment>
-    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
-    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
-    <rdfs:label>Physical properties</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
-    <rdfs:label>Ion channels</rdfs:label>
-    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated">
-    <rdfs:label>Pumps</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
-    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_delayed_rectifier_potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:comment>Reversal potential for the IKr current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>IKr reversal potential</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Transition rates and related parameters</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated">
-    <rdfs:comment>Terms related to proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdfs:label>Ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
-    <rdfs:label>Potassium reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance_scaling_factor">
-    <rdfs:label>Membrane inward rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
-    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
-    <rdfs:label>State variable</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane background sodium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
-    <rdfs:label>Patch clamp properties</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Universal constants</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
-    <rdfs:label>Mammalian</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchangerRelated">
-    <rdfs:label>Exchangers</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_GHK_driving_term">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
-    <rdfs:label>Membrane L-type calcium current GHK driving term</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_chloride_concentration">
-    <rdfs:label>Cytosolic chloride concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcacyt">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:label>Sarcoplasmic reticulum release kmcacyt</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_a_parameter">
-    <rdfs:comment>'a' parameter in a transition rate with linear voltage dependence, of the form a*exp(±b*V)</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
-    <rdfs:label>'a' parameter in a transition rate of the form a*exp(±b*V)</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
-    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Annotations that can appear on more than one variable in a model.</rdfs:label>
-    <rdfs:comment>This indicates to the annotation tool that it should allow multiple occurrences.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrent">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdfs:label>Stimulus current and its properties</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time">
-    <rdfs:label>Time</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdfs:comment>The independent variable, the simulation time.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
-    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
-    <rdfs:label>Voltage across the cell membrane</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
-    <rdfs:label>The value of a measured quantity</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sodium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Reversal potential of sodium ions across the cell membrane</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Sodium reversal potential</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
-    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Ionic concentrations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
-    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_V_negative_rate">
-    <rdfs:label>Transition rate k of the form k=a*exp(-b*V)</rdfs:label>
-    <rdfs:comment>Transition rate k with negative linear voltage dependence of the form k=a*exp(-b*V)</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
-    <rdfs:label>Cell type</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
-    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#concentration_clamp_onoff">
-    <rdfs:comment>Deprecated</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current_conductance">
-    <rdfs:label>Membrane transient outward chloride current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
-    <rdfs:comment>NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR).</rdfs:comment>
-    <rdfs:label>Sodium-calcium exchanger current into dyadic space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
-    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
-    <rdfs:label>The units of a measured quantity</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
-    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
-    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane persistent sodium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
-    <rdfs:label>Extracellular calcium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
-    <rdfs:label>Membrane currents and their properties</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
-    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Membrane potassium current conductance</rdfs:label>
-  </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
     <rdfs:label>Membrane fast sodium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
-    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>Temperature measurement</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
-    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Membrane slow inward current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
-    <rdfs:label>Membrane calcium pump current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Potassium channel n gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
-    <rdfs:label>Membrane background potassium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular chloride concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance_scaling_factor">
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane transient outward current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
-    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
-    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
-    <rdfs:label>Implicit Variable Annotation</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated">
-    <rdfs:label>Terms related to potassium ion channels</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current j gate tau</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
-    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_concentration">
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-    <rdfs:label>Concentration of calcium ions in the sub-membrane compartment</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane fast sodium current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-    <rdfs:label>Membrane background chloride current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period">
-    <rdfs:label>Membrane stimulus current pulse period</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#right_ventricular">
-    <rdfs:label>Right ventricular</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated">
-    <rdfs:comment>Terms related to proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdfs:label>Exchangers</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rabbit">
-    <rdfs:label>Rabbit</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_end">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdfs:label>Membrane stimulus current pulse end time</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
-    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
-    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
-    <rdfs:label>SR currents</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-    <rdfs:label>Membrane persistent sodium current conductance scaling factor</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
-    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CustomAnnotations">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Custom annotations</rdfs:label>
-    <rdfs:comment>Custom annotations in other namespaces referenced by protocols.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
-    <rdfs:label>Chloride reversal potential</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated">
-    <rdfs:label>Terms related to calcium ion channels</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
-    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current conductance scaling factor</rdfs:label>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent">
-    <rdfs:label>Ionic currents</rdfs:label>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>All terms that represent a current anywhere in the cell.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
-    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
-    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Ventricular</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated">
-    <rdfs:label>Terms related to mixed ion channels</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#epicardial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>(Sub)epicardial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_open_probability">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane L-type calcium current open probability</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
-    <rdfs:label>Left ventricular</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dog">
-    <rdfs:label>Dog</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
+    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
-    <rdfs:label>A category of annotations</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#NSR_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdfs:comment>The network SR is the non-junctional part of the SR.</rdfs:comment>
+    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
+    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
+    <rdfs:label>Implicit Variable Annotation</rdfs:label>
+    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#atrial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Atrial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
-    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
-    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration">
-    <rdfs:label>Ionic concentrations in the SR</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_r_gate">
-    <rdfs:label>Membrane transient outward current r gate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term">
-    <rdfs:label>Membrane L-type calcium current driving term (GHK or ohmic)</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-    <rdfs:label>Terms related to sodium ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate">
-    <rdfs:label>Ion channel state transition rate</rdfs:label>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
   </rdf:Description>
 </rdf:RDF>

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -169,7 +169,7 @@
     rdfs:label "Membrane currents and their properties" ;
     rdfs:comment "Annotations associated with currents across the cell membrane." .
 
-:StimulusCurrent
+:StimulusCurrentRelated
     a :CellMembraneCurrentRelated ;
     a :ChasteMetadata ;
     rdfs:label "Stimulus current and its properties" .


### PR DESCRIPTION
The renaming went a bit wrong!

Will fix https://github.com/ModellingWebLab/WebLab/issues/344 once deployed.