### PR TITLE
added annotation for probabilities that do not stay in range 0...1

### DIFF
--- a/oxford-metadata.rdf
+++ b/oxford-metadata.rdf
@@ -4,28 +4,192 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 >
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#NSR_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
+    <rdfs:comment>The network SR is the non-junctional part of the SR.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane potassium current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane background potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Ionic currents</rdfs:label>
+    <rdfs:comment>All terms that represent a current anywhere in the cell.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_delayed_rectifier_potassium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>IKr reversal potential</rdfs:label>
+    <rdfs:comment>Reversal potential for the IKr current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane stimulus current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
+    <rdfs:label>Ion channels</rdfs:label>
+    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_cleft_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration"/>
+    <rdfs:label>Sodium concentration in the extracellular cleft</rdfs:label>
+    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcacyt">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdfs:label>Sarcoplasmic reticulum release kmcacyt</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdfs:label>Time</rdfs:label>
+    <rdfs:comment>The independent variable, the simulation time.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
+    <rdfs:label>Left ventricular</rdfs:label>
+  </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
     <rdfs:label>Concentration of calcium ions in the sub-membrane compartment</rdfs:label>
     <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
+    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>A maximal conductance or permeability parameter</rdfs:label>
+    <rdfs:comment>Tags for maximal conductance or permeability when open probability is equal to one (these may be algebraic expressions as well as constants).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
+    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular chloride concentration</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
@@ -35,281 +199,19 @@
     <rdfs:label>Membrane leakage current</rdfs:label>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
-    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular ionic concentrations, close to the cell</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane background potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Universal constants</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
-    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-    <rdfs:label>Terms related to calcium ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
-    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdfs:label>Ion channels</rdfs:label>
-    <rdfs:comment>Terms related to proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Probability">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Probability</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
-    <rdfs:label>Membrane fast transient outward current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_GHK_driving_term">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
-    <rdfs:label>Membrane L-type calcium current GHK driving term</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane L-type calcium channel potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane plateau potassium current</rdfs:label>
+    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Chloride reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-    <rdfs:label>Terms related to sodium ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Species</rdfs:label>
-    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane potassium pump current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
+    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdfs:label>Cell membrane capacitance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane fast sodium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
-    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane ATP-dependent potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Probability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdfs:label>Hodgkin-Huxley Gate</rdfs:label>
-    <rdfs:comment>For any state variable which is a Hodgkin-Huxley gating variable.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CustomAnnotations">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Custom annotations</rdfs:label>
-    <rdfs:comment>Custom annotations in other namespaces referenced by protocols.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#time">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdfs:label>Time</rdfs:label>
-    <rdfs:comment>The independent variable, the simulation time.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rabbit">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:label>Rabbit</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-    <rdfs:label>Terms related to potassium ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:label>Mammalian</rdfs:label>
-    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current conductance or permeability</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane slow inward current</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular sodium concentration</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_leakage_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
@@ -319,54 +221,11 @@
     <rdfs:label>Membrane leakage current conductance</rdfs:label>
     <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane stimulus current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_V_negative_rate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate"/>
-    <rdfs:label>Transition rate k of the form k=a*exp(-b*V)</rdfs:label>
-    <rdfs:comment>Transition rate k with negative linear voltage dependence of the form k=a*exp(-b*V)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_bath_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration"/>
-    <rdfs:label>Calcium concentration in the extracellular bath</rdfs:label>
-    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane L-type calcium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane background potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_b_parameter">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
@@ -375,17 +234,587 @@
     <rdfs:label>'b' parameter in a transition rate of the form a*exp(±b*V)</rdfs:label>
     <rdfs:comment>'b' parameter in a transition rate with linear voltage dependence, of the form a*exp(±b*V)</rdfs:comment>
   </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Implicit Variable Annotation</rdfs:label>
+    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_end">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdfs:label>Membrane stimulus current pulse end time</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_V_positive_rate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate"/>
+    <rdfs:label>Transition rate k of the form k=a*exp(+b*V)</rdfs:label>
+    <rdfs:comment>Transition rate k with positive linear voltage dependence of the form k=a*exp(+b*V)</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Sarcoplasmic reticulum release current</rdfs:label>
+    <rdfs:comment>Also known as Jrel or RyR channel current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Cell type</rdfs:label>
+    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular sodium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane transient outward chloride current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:label>Terms related to mixed ion channels</rdfs:label>
+    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#markov_model_state">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Probability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:label>Markov Model State</rdfs:label>
+    <rdfs:comment>For any state variable which is a state in a Markov model for an ion channel.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
+    <rdfs:comment>TODO!</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CustomAnnotations">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Custom annotations</rdfs:label>
+    <rdfs:comment>Custom annotations in other namespaces referenced by protocols.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#mammalian">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Mammalian</rdfs:label>
+    <rdfs:comment>Unspecified, unknown or mixed mammalian species.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>A category of annotations</rdfs:label>
+    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular potassium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_open_probability">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Probability"/>
+    <rdfs:label>Membrane L-type calcium current open probability</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Transition rates and related parameters</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_cleft_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration"/>
+    <rdfs:label>Calcium concentration in the extracellular cleft</rdfs:label>
+    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dog">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Dog</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane L-type calcium channel sodium current conductance or permeability</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane plateau potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane persistent sodium current conductance</rdfs:label>
+    <rdfs:comment>Also known as membrane late sodium current conductance</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane background sodium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Universal constants</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic chloride concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdfs:label>Membrane stimulus current pulse start offset</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
+  </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance_scaling_factor">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
     <rdfs:label>Membrane sodium-calcium exchanger current conductance scaling factor</rdfs:label>
     <rdfs:comment>Also known as permeability</rdfs:comment>
   </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current j gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
+    <rdfs:label>Membrane slow transient outward current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:label>Pumps</rdfs:label>
+    <rdfs:comment>Terms related to proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdfs:label>Stimulus current and its properties</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current d gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
+    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:label>Terms related to sodium ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_cleft_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration"/>
+    <rdfs:label>Potassium concentration in the extracellular cleft</rdfs:label>
+    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:label>Concentration of chloride ions in the sub-membrane compartment</rdfs:label>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>Temperature measurement</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane potassium pump current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
+    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>The units of a measured quantity</rdfs:label>
+    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#JSR_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdfs:label>Concentration of calcium in the junctional sarcoplasmic reticulum</rdfs:label>
+    <rdfs:comment>The junctional SR is that portion near the RyRs.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>SR currents</rdfs:label>
+    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane background sodium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane persistent sodium current</rdfs:label>
+    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_a_parameter">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter"/>
+    <rdfs:label>'a' parameter in a transition rate of the form a*exp(±b*V)</rdfs:label>
+    <rdfs:comment>'a' parameter in a transition rate with linear voltage dependence, of the form a*exp(±b*V)</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:label>Concentration of potassium in the dyadic sub-space</rdfs:label>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Calcium reversal potential</rdfs:label>
+    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane calcium pump current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr1_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Rapid time-dependent potassium current Xr1 gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
+  </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_r_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
     <rdfs:label>Membrane transient outward current r gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane background chloride current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_V_negative_rate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate"/>
+    <rdfs:label>Transition rate k of the form k=a*exp(-b*V)</rdfs:label>
+    <rdfs:comment>Transition rate k with negative linear voltage dependence of the form k=a*exp(-b*V)</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_bath_chloride_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration"/>
+    <rdfs:label>Chloride concentration in the extracellular bath</rdfs:label>
+    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Slow time-dependent potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular ionic concentrations, far from the cell</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Basic Chaste metadata</rdfs:label>
+    <rdfs:comment>Core annotations needed for a model to work well with the Chaste simulator.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
+    <rdfs:comment>TODO!</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#chloride_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Chloride reversal potential</rdfs:label>
+    <rdfs:comment>Reversal potential of chloride ions across the cell membrane</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
+    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:label>Concentration of calcium in the dyadic sub-space</rdfs:label>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_delayed_rectifier_potassium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>IKs reversal potential</rdfs:label>
+    <rdfs:comment>Reversal potential for the IKs current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:label>Exchangers</rdfs:label>
+    <rdfs:comment>Terms related to proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_bath_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration"/>
+    <rdfs:label>Sodium concentration in the extracellular bath</rdfs:label>
+    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
+    <rdfs:label>Membrane transient outward current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_bath_potassium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration"/>
+    <rdfs:label>Potassium concentration in the extracellular bath</rdfs:label>
+    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Membrane currents and their properties</rdfs:label>
+    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Ionic concentrations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
+    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane slow inward current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current conductance</rdfs:label>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated"/>
+    <rdfs:label>Parameters for transition rate equations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
+    <rdfs:label>Faraday's constant - F</rdfs:label>
+    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata">
     <dcterms:abstract>Chaste metadata for annotating CellML files representing cardiac electrophysiology models.</dcterms:abstract>
@@ -422,385 +851,9 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT&#1
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.&#13;
 </dcterms:license>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane L-type calcium channel sodium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_open_probability">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Probability"/>
-    <rdfs:label>Membrane L-type calcium current open probability</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane slow transient outward current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#left_ventricular">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#right_ventricular">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
-    <rdfs:label>Left ventricular</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Physical properties</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance1">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 1</rdfs:label>
-    <rdfs:comment>TODO!</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
-    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdfs:label>Temperature</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#human">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:label>Human (Homo Sapiens)</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current j gate tau</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#organism">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>identifies the organism this data/model is about</rdfs:label>
-    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Rapid time-dependent potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
-    <rdfs:label>Voltage across the cell membrane</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane persistent sodium current</rdfs:label>
-    <rdfs:comment>Also known as membrane late sodium current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Annotations that can appear on more than one variable in a model.</rdfs:label>
-    <rdfs:comment>This indicates to the annotation tool that it should allow multiple occurrences.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:label>Concentration of potassium ions in the sub-membrane compartment</rdfs:label>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_a_parameter">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter"/>
-    <rdfs:label>'a' parameter in a transition rate of the form a*exp(±b*V)</rdfs:label>
-    <rdfs:comment>'a' parameter in a transition rate with linear voltage dependence, of the form a*exp(±b*V)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>A category of annotations</rdfs:label>
-    <rdfs:comment>A class for classes that contain annotations, used to build a tree hierarchy in the annotation UI.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdfs:label>Cytosolic potassium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current fCa gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#calcium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Calcium reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential of calcium ions across the cell membrane</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane potassium current</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-    <rdfs:label>Membrane stimulus current pulse period</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#markov_model_state">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Probability"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdfs:label>Markov Model State</rdfs:label>
-    <rdfs:comment>For any state variable which is a state in a Markov model for an ion channel.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCass_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current fCass gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Patch clamp properties</rdfs:label>
-    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_channel_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane L-type calcium channel potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane persistent sodium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:comment>I_to is a potassium current, sometimes subdivided into fast and slow components (a.k.a. I_to1)</rdfs:comment>
-    <rdfs:label>Membrane transient outward current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane background chloride current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_pump_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane potassium pump current conductance</rdfs:label>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the cytosol due to buffering</rdfs:label>
-    <rdfs:comment>This term annotates how calcium fluxes in the cytosol are scaled due to intrinsic (natural) buffering</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#epicardial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>(Sub)epicardial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
-    <rdfs:label>State variable</rdfs:label>
-    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdfs:label>Exchangers</rdfs:label>
-    <rdfs:comment>Terms related to proteins that use the energy of one ionic species moving down an electrochemical gradient, to move another species against its gradient.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#NSR_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
-    <rdfs:label>Concentration of calcium in the network sarcoplasmic reticulum</rdfs:label>
-    <rdfs:comment>The network SR is the non-junctional part of the SR.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>A maximal conductance or permeability parameter</rdfs:label>
-    <rdfs:comment>Tags for maximal conductance or permeability when open probability is equal to one (these may be algebraic expressions as well as constants).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Potassium channel n gate</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_time_dependent_potassium_current_Xs_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Slow time-dependent potassium current Xs gate</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane fast transient outward current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_cleft_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration"/>
-    <rdfs:label>Chloride concentration in the extracellular cleft</rdfs:label>
-    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#exp2_V_positive_rate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate"/>
-    <rdfs:label>Transition rate k of the form k=a*exp(+b*V)</rdfs:label>
-    <rdfs:comment>Transition rate k with positive linear voltage dependence of the form k=a*exp(+b*V)</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_chloride_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane background chloride current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
-    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Ventricular</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
-    <rdfs:comment>Often known as INaK_max</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular ionic concentrations, far from the cell</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Membrane currents and their properties</rdfs:label>
-    <rdfs:comment>Annotations associated with currents across the cell membrane.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane slow transient outward current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
-    <rdfs:label>Pumps</rdfs:label>
-    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular calcium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#seal_resistance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdfs:label>Patch clamp seal resistance</rdfs:label>
-    <rdfs:comment>Patch clamp seal resistance</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_time_dependent_potassium_current_Xr2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Rapid time-dependent potassium current Xr2 gate</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdfs:label>Cytosolic chloride concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateParameter">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated"/>
-    <rdfs:label>Parameters for transition rate equations</rdfs:label>
+    <rdfs:label>Right ventricular</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current_conductance_scaling_factor">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
@@ -808,346 +861,10 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.&
     <rdfs:label>Membrane fast transient outward current conductance scaling factor</rdfs:label>
     <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdfs:label>Cytosolic sodium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-    <rdfs:label>Terms related to mixed ion channels</rdfs:label>
-    <rdfs:comment>Membrane ion channels that don't fit a more specific categorisation, or transport multiple species.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
-    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_bath_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration"/>
-    <rdfs:label>Potassium concentration in the extracellular bath</rdfs:label>
-    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>SR currents</rdfs:label>
-    <rdfs:comment>Annotations associated with currents across the sarcoplasmic reticulum membrane.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
-    <rdfs:label>The value of a measured quantity</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
-    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_ohmic_driving_term">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
-    <rdfs:label>Membrane L-type calcium current Ohmic driving term</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane L-type calcium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_cleft_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration"/>
-    <rdfs:label>Sodium concentration in the extracellular cleft</rdfs:label>
-    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane transient outward current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Extracellular ionic concentrations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Variable Annotation</rdfs:label>
-    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Cell type</rdfs:label>
-    <rdfs:comment>The class of typical cell types found in cardiac models.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current driving term (GHK or ohmic)</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane transient outward current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#right_ventricular">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular"/>
-    <rdfs:label>Right ventricular</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#faraday_constant">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
-    <rdfs:label>Faraday's constant - F</rdfs:label>
-    <rdfs:comment>Equal to the electical charge on one mole of electrons.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane calcium pump current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
-    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
-    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_bath_sodium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration"/>
-    <rdfs:label>Sodium concentration in the extracellular bath</rdfs:label>
-    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current fCa2 gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
-    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Ionic concentrations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
-    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
-    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane delayed rectifier potassium current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_potassium_component_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current potassium component conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Buffering</rdfs:label>
-    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane inward rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs2_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs2 gate tau</rdfs:label>
-    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane background sodium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_single_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current single gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-    <rdfs:label>Membrane stimulus current pulse amplitude</rdfs:label>
-    <rdfs:comment>This should be negative in order to cause a positive change in voltage.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#concentration_clamp_onoff">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdfs:comment>Deprecated</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_cleft_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration"/>
-    <rdfs:label>Potassium concentration in the extracellular cleft</rdfs:label>
-    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Ionic currents</rdfs:label>
-    <rdfs:comment>All terms that represent a current anywhere in the cell.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_bath_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration"/>
-    <rdfs:label>Chloride concentration in the extracellular bath</rdfs:label>
-    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular chloride concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance2">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance 2</rdfs:label>
-    <rdfs:comment>TODO!</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_chloride_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
-    <rdfs:label>Concentration of chloride ions in the sub-membrane compartment</rdfs:label>
-    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_sodium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane background sodium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Ionic concentrations in the SR</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Potassium reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#atrial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Atrial</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current_max">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
-    <rdfs:label>Sarcoplasmic reticulum uptake current max</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sino_atrial_node">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Sino-atrial node</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Transition rates and related parameters</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hiPSC">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>Human induced pluripotent stem cell</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Cytosolic ionic concentrations</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchangerRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
-    <rdfs:label>Exchangers</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_delayed_rectifier_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane delayed rectifier potassium current</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance_scaling_factor">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance scaling factor</rdfs:label>
-    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cell_type">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label>identifies the cell type this data/model is about</rdfs:label>
+    <rdfs:range rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
@@ -1155,44 +872,35 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.&
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
     <rdfs:label>Membrane background calcium current</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#slow_delayed_rectifier_potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>IKs reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential for the IKs current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Sodium-calcium exchanger current into dyadic space conductance</rdfs:label>
-    <rdfs:comment>Also known as permeability</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_rapid_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane rapid delayed rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d_gate_power_tau">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current d gate power tau</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_shift_inactivation">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sodium_reversal_potential">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
-    <rdfs:label>Membrane fast sodium current shift inactivation</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Sodium reversal potential</rdfs:label>
+    <rdfs:comment>Reversal potential of sodium ions across the cell membrane</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hasTemperature">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>Temperature measurement</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#cytosolic_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration"/>
+    <rdfs:label>Cytosolic calcium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#gas_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Constant"/>
+    <rdfs:label>Ideal Gas Constant - R</rdfs:label>
+    <rdfs:comment>Also known as the Molar or Universal gas constant.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#not_a_probability_even_though_it_should_be">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Probability"/>
+    <rdfs:label>Probability that does not stay within 0 ... 1 range</rdfs:label>
+    <rdfs:comment>This should be a probability but it is not guaranteed to stay within 0 ... 1 range.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCa gate tag</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_dyadic_space_current">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
@@ -1201,120 +909,34 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.&
     <rdfs:comment>NaCa exchanger current across the cell membrane adjacent to dyadic space (i.e near SR).</rdfs:comment>
     <rdfs:label>Sodium-calcium exchanger current into dyadic space</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
-    <rdfs:label>Terms related to chloride ion channels</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_inward_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane slow inward current conductance</rdfs:label>
-    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
-    <rdfs:label>Ion channels</rdfs:label>
-    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_cleft_calcium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration"/>
-    <rdfs:label>Calcium concentration in the extracellular cleft</rdfs:label>
-    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcacyt">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-    <rdfs:label>Sarcoplasmic reticulum release kmcacyt</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_potassium_concentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
-    <rdfs:label>Extracellular potassium concentration</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:comment>I_to slow is a potassium current, (a.k.a. I_to1 slow)</rdfs:comment>
-    <rdfs:label>Membrane slow transient outward current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_end">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
-    <rdfs:label>Membrane stimulus current pulse end time</rdfs:label>
+    <rdfs:label>Membrane stimulus current pulse duration</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
-    <rdfs:label>Stimulus current and its properties</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_cleft_chloride_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration"/>
+    <rdfs:label>Chloride concentration in the extracellular cleft</rdfs:label>
+    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
+    <rdfs:label>Membrane L-type calcium current</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_calcium_flux_scaling_from_intrinsic_buffers">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current conductance</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:label>Scaling factor for calcium fluxes in the dyadic sub-space due to buffering</rdfs:label>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules). This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_chloride_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
-    <rdfs:label>Membrane hyperpolarisation-activated funny current</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dog">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
-    <rdfs:label>Dog</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current_conductance">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane transient outward chloride current conductance</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Ionic concentrations in the sub-membrane space</rdfs:label>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rapid_delayed_rectifier_potassium_reversal_potential">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>IKr reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential for the IKr current across the cell membrane, for when it isn't the general potassium_reversal_potential</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated"/>
-    <rdfs:label>Ion channel state transition rate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:label>Concentration of chloride ions in the dyadic sub-space</rdfs:label>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
@@ -1322,55 +944,178 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.&
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
     <rdfs:label>Membrane fast sodium current conductance</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
-    <rdfs:label>Pumps</rdfs:label>
-    <rdfs:comment>Terms related to proteins that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_calcium_concentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
-    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration"/>
+    <rdfs:label>Concentration of calcium in the sarcoplasmic reticulum</rdfs:label>
+    <rdfs:comment>Some models treat the SR as a whole, and do not decompose it into different regions.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_xs1_gate_tau">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Ionic concentrations in the cleft / dyadic space</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Species</rdfs:label>
+    <rdfs:comment>The class of typical species found in cardiac models.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_m_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
-    <rdfs:label>Membrane slow delayed rectifier potassium current xs1 gate tau</rdfs:label>
-    <rdfs:comment>Really a scaling factor for tau</rdfs:comment>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current m gate</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#units">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>The units of a measured quantity</rdfs:label>
-    <rdfs:comment>The list of allowed values is not kept as an ontology, but is mapped by name to CellML/pint/Sympy definitions.</rdfs:comment>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current_conductance">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_potassium_current_conductance">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
-    <rdfs:label>Membrane non-inactivating steady-state potassium current conductance</rdfs:label>
+    <rdfs:label>Membrane potassium current conductance</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_s_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane transient outward current s gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdfs:label>Cell membrane capacitance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_d2_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current d2 gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_plateau_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane plateau potassium current</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularCleftConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular ionic concentrations, close to the cell</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#dyadic_space_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CleftConcentration"/>
+    <rdfs:label>Concentration of sodium in the dyadic sub-space</rdfs:label>
+    <rdfs:comment>Some models also have a separate dyadic sub-space (cytosol between JSR and t-tubules).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current h gate tau</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
-    <rdfs:label>Basic Chaste metadata</rdfs:label>
-    <rdfs:comment>Core annotations needed for a model to work well with the Chaste simulator.</rdfs:comment>
+    <rdfs:label>Patch clamp properties</rdfs:label>
+    <rdfs:comment>Properties of the patch clamp experimental setup represented explicitly in models.</rdfs:comment>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#measures">
-    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
-    <rdfs:label>Describes which ontology term a CSV column is a measurement of.</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#rabbit">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Species"/>
+    <rdfs:label>Rabbit</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2_gate_tau">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_calcium_exchanger_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneExchangerRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane sodium-calcium exchanger current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ventricular">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Ventricular</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Annotations that can appear on more than one variable in a model.</rdfs:label>
+    <rdfs:comment>This indicates to the annotation tool that it should allow multiple occurrences.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_sodium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SubMembraneConcentration"/>
+    <rdfs:label>Concentration of sodium ions in the sub-membrane compartment</rdfs:label>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#seal_resistance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdfs:label>Patch clamp seal resistance</rdfs:label>
+    <rdfs:comment>Patch clamp seal resistance</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_uptake_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Sarcoplasmic reticulum uptake current</rdfs:label>
+    <rdfs:comment>Also known as Jup or SERCA current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:label>Variable Annotation</rdfs:label>
+    <rdfs:comment>The class of IRIs that can annotate variables in a CellML model.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_GHK_driving_term">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
-    <rdfs:label>Membrane L-type calcium current f2 gate</rdfs:label>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
+    <rdfs:label>Membrane L-type calcium current GHK driving term</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#endocardial">
-    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
-    <rdfs:label>(Sub)endocardial</rdfs:label>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current f gate</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation">
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:label>Implicit Variable Annotation</rdfs:label>
-    <rdfs:comment>The class of IRIs that implicitly annotate variables in a CellML model (i.e. are added automatically by tools).</rdfs:comment>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRPumpRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
+    <rdfs:label>Pumps</rdfs:label>
+    <rdfs:comment>Terms related to proteins in the sarcoplasmic reticulum membrane that use energy in ATP to pump ions against their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_background_calcium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane background calcium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CytosolicConcentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Cytosolic ionic concentrations</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#temperature">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Temperature</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#submembrane_space_calcium_flux_scaling_from_intrinsic_buffers">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm"/>
+    <rdfs:label>Scaling factor for calcium fluxes in the submembrane space due to buffering</rdfs:label>
+    <rdfs:comment>Some models have a separate compartment underlying the entire cell membrane, distinct from the dyadic sub-space. This term annotates how calcium fluxes here are scaled due to buffering</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_non_inactivating_steady_state_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane non-inactivating steady-state potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_reversal_potential">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
+    <rdfs:label>Potassium reversal potential</rdfs:label>
+    <rdfs:comment>Reversal potential of potassium ions across the cell membrane</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_transient_outward_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:comment>I_to fast is a potassium current, (a.k.a. I_to1 fast)</rdfs:comment>
+    <rdfs:label>Membrane fast transient outward current</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_h_gate">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
@@ -1378,11 +1123,273 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.&
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
     <rdfs:label>Membrane fast sodium current h gate</rdfs:label>
   </rdf:Description>
-  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sodium_reversal_potential">
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane sodium-potassium pump current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_calcium_pump_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane calcium pump current conductance</rdfs:label>
+    <rdfs:comment>Also known as permeability</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#potassium_channel_n_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Potassium channel n gate</rdfs:label>
+    <rdfs:comment>Historical metadata - only for early models lacking components.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Physical properties</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_reduced_inactivation">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current reduced inactivation</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa2_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current fCa2 gate tau</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_atp_dependent_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane ATP-dependent potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#leakage_compensation_percentage">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PatchClampProperties"/>
+    <rdfs:label>Percentage of seal leakage compensation current to include</rdfs:label>
+    <rdfs:comment>Percentage of seal leakage compensation current to include</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularConcentration"/>
+    <rdfs:label>Extracellular calcium concentration</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane inward rectifier potassium current conductance</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_sodium_potassium_pump_current_permeability">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePumpRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ConductanceOrPermeability"/>
+    <rdfs:label>Membrane sodium-potassium pump current permeability</rdfs:label>
+    <rdfs:comment>Often known as INaK_max</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#extracellular_bath_calcium_concentration">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ExtracellularBathConcentration"/>
+    <rdfs:label>Calcium concentration in the extracellular bath</rdfs:label>
+    <rdfs:comment>Some models divide the extracellular space into 'bath' (far from the cell) and 'cleft' (near the cell).</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_time_independent_rectification_gate_constant">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane transient outward current time-independent rectification gate constant</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRExchangerRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRCurrentRelated"/>
+    <rdfs:label>Exchangers</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_ohmic_driving_term">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term"/>
+    <rdfs:label>Membrane L-type calcium current Ohmic driving term</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#state_variable">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ImplicitAnnotation"/>
+    <rdfs:label>State variable</rdfs:label>
+    <rdfs:comment>Indicates a dependent variable in the model. Does not need to be specified explicitly: the Functional Curation tools will automatically annotate all state variables in the modified model.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Probability">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Probability</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#StimulusCurrentRelated"/>
+    <rdfs:label>Membrane stimulus current pulse period</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane inward rectifier potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#concentration_clamp_onoff">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdfs:comment>Deprecated</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#endocardial">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>(Sub)endocardial</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:label>Ion channels</rdfs:label>
+    <rdfs:comment>Terms related to proteins allowing certain ions to flow down their electrochemical gradients.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_inward_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane inward rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#epicardial">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>(Sub)epicardial</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_transient_outward_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane slow transient outward current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_ultrarapid_delayed_rectifier_potassium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane ultrarapid delayed rectifier potassium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_slow_delayed_rectifier_potassium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane slow delayed rectifier potassium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_hyperpolarisation_activated_funny_current_sodium_component">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneMixedChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane hyperpolarisation-activated funny current sodium component</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_chloride_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:comment>Calcium activated transient outward chloride current, commonly known as Ito2</rdfs:comment>
+    <rdfs:label>Membrane transient outward chloride current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_persistent_sodium_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane persistent sodium current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MultipleUsesAllowed"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Probability"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellMembraneCurrentRelated"/>
+    <rdfs:label>Hodgkin-Huxley Gate</rdfs:label>
+    <rdfs:comment>For any state variable which is a Hodgkin-Huxley gating variable.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#BufferingTerm">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Category"/>
+    <rdfs:label>Buffering</rdfs:label>
+    <rdfs:comment>Annotations needed for studying and altering ionic buffering.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:label>Terms related to potassium ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdfs:label>Sarcoplasmic reticulum leak current max</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_current_max">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdfs:label>Sarcoplasmic reticulum release current max</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_f2ds_gate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#hodgkin_huxley_gate"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current f2ds gate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#ChasteMetadata"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#PhysicalProperty"/>
+    <rdfs:label>Voltage across the cell membrane</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#atrial">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Atrial</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_transient_outward_current_conductance_scaling_factor">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembranePotassiumChannelRelated"/>
+    <rdfs:label>Membrane transient outward current conductance scaling factor</rdfs:label>
+    <rdfs:comment>A scalar that multiplies the conductance term for this current</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Membrane fast sodium current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneChlorideChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:label>Terms related to chloride ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_fast_sodium_current_j_gate_tau">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneSodiumChannelRelated"/>
+    <rdfs:label>Membrane fast sodium current j gate tau</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneIonChannelRelated"/>
+    <rdfs:label>Terms related to calcium ion channels</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRConcentration">
     <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Concentration"/>
-    <rdfs:label>Sodium reversal potential</rdfs:label>
-    <rdfs:comment>Reversal potential of sodium ions across the cell membrane</rdfs:comment>
+    <rdfs:label>Ionic concentrations in the SR</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_leak_current">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#IonicCurrent"/>
+    <rdfs:label>Sarcoplasmic reticulum leak current</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#value">
+    <rdfs:label>The value of a measured quantity</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SR_release_kmcads">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#Annotation"/>
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#SRIonChannelRelated"/>
+    <rdfs:label>Sarcoplasmic reticulum release kmcads</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_driving_term">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#MembraneCalciumChannelRelated"/>
+    <rdfs:label>Membrane L-type calcium current driving term (GHK or ohmic)</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRate">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#TransitionRateRelated"/>
+    <rdfs:label>Ion channel state transition rate</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#sino_atrial_node">
+    <rdf:type rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#CellType"/>
+    <rdfs:label>Sino-atrial node</rdfs:label>
   </rdf:Description>
 </rdf:RDF>

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -339,7 +339,7 @@
     a :MultipleUsesAllowed ;
     a :Probability ;
     rdfs:label "Probability that does not stay within 0 ... 1 range" ;
-    rdfs:comment "This should be a probability but it is not guaranteed to stay within 0 ... 1 range." .
+    rdfs:comment "This should be a probability but it is not guaranteed to stay within [0,1] because of unusual mathematical formulation. Introduced to prevent checks being generated in code for quantities annotated with this tag" .
 
 # ======================================================================
 # Cardiac-Specific Labels

--- a/oxford-metadata.ttl
+++ b/oxford-metadata.ttl
@@ -334,6 +334,13 @@
     rdfs:label "Markov Model State" ;
     rdfs:comment "For any state variable which is a state in a Markov model for an ion channel." .
 
+:not_a_probability_even_though_it_should_be
+    a :Annotation ;
+    a :MultipleUsesAllowed ;
+    a :Probability ;
+    rdfs:label "Probability that does not stay within 0 ... 1 range" ;
+    rdfs:comment "This should be a probability but it is not guaranteed to stay within 0 ... 1 range." .
+
 # ======================================================================
 # Cardiac-Specific Labels
 # ======================================================================


### PR DESCRIPTION
I tried this by tagging in ten_tusscher_model_2004_epi
```
    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
        <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="#membrane_L_type_calcium_current_fCa_gate">
            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_L_type_calcium_current_fCa_gate" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
            <bqbiol:is xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#not_a_probability_even_though_it_should_be" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
        </rdf:Description>
    </rdf:RDF>
```
That way I can easily exclude the not quite probabilities from checks, while for other purposes (the stories) they're still probabilities.